### PR TITLE
Update installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This is a package for working with infinite MPS based on the [ITensors.jl](https
 
 The package is currently not registered. Please install with the commands:
 ```julia
-julia> using Pkg; Pkg.add("https://github.com/mtfishman/ITensorInfiniteMPS.jl.git")
+julia> using Pkg; Pkg.add(url="https://github.com/mtfishman/ITensorInfiniteMPS.jl.git")
 ```
 
 ## Examples


### PR DESCRIPTION
Pkg.add(..) takes the package url as a "url" keyword argument now