### PR TITLE
Add `eigsolve_tol` as a keyword argument for the eigensolver

### DIFF
--- a/.github/workflows/format_check.yml
+++ b/.github/workflows/format_check.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        julia-version: [1.3.0]
+        julia-version: [1.7.1]
         julia-arch: [x86]
         os: [ubuntu-latest]
     steps:

--- a/src/vumps_localham.jl
+++ b/src/vumps_localham.jl
@@ -201,9 +201,8 @@ function vumps_iteration_sequential(
   ψ::InfiniteCanonicalMPS;
   (ϵᴸ!)=fill(1e-15, nsites(ψ)),
   (ϵᴿ!)=fill(1e-15, nsites(ψ)),
-  eigsolve_tol=( x -> x/100 ),
+  eigsolve_tol=(x -> x / 100),
 )
-
   Nsites = nsites(ψ)
   ϵᵖʳᵉˢ = max(maximum(ϵᴸ!), maximum(ϵᴿ!))
   krylov_tol = eigsolve_tol(ϵᵖʳᵉˢ)
@@ -330,7 +329,7 @@ function vumps_iteration_parallel(
   ψ::InfiniteCanonicalMPS;
   (ϵᴸ!)=fill(1e-15, nsites(ψ)),
   (ϵᴿ!)=fill(1e-15, nsites(ψ)),
-  eigsolve_tol=(x -> x/100),
+  eigsolve_tol=(x -> x / 100),
 )
   Nsites = nsites(ψ)
   ϵᵖʳᵉˢ = max(maximum(ϵᴸ!), maximum(ϵᴿ!))
@@ -423,7 +422,13 @@ function vumps_iteration_parallel(
 end
 
 function vumps(
-  ∑h, ψ; maxiter=10, tol=1e-8, outputlevel=1, multisite_update_alg="sequential", eigsolve_tol=( x ->x/100 ),
+  ∑h,
+  ψ;
+  maxiter=10,
+  tol=1e-8,
+  outputlevel=1,
+  multisite_update_alg="sequential",
+  eigsolve_tol=(x -> x / 100),
 )
   N = nsites(ψ)
   (ϵᴸ!) = fill(tol, nsites(ψ))
@@ -432,7 +437,12 @@ function vumps(
     println("Running VUMPS with multisite_update_alg = $multisite_update_alg")
   for iter in 1:maxiter
     ψ, (eᴸ, eᴿ) = vumps_iteration(
-      ∑h, ψ; (ϵᴸ!)=(ϵᴸ!), (ϵᴿ!)=(ϵᴿ!), multisite_update_alg=multisite_update_alg, eigsolve_tol=eigsolve_tol,
+      ∑h,
+      ψ;
+      (ϵᴸ!)=(ϵᴸ!),
+      (ϵᴿ!)=(ϵᴿ!),
+      multisite_update_alg=multisite_update_alg,
+      eigsolve_tol=eigsolve_tol,
     )
     ϵᵖʳᵉˢ = max(maximum(ϵᴸ!), maximum(ϵᴿ!))
     maxdimψ = maxlinkdim(ψ[0:(N + 1)])

--- a/src/vumps_localham.jl
+++ b/src/vumps_localham.jl
@@ -201,10 +201,12 @@ function vumps_iteration_sequential(
   ψ::InfiniteCanonicalMPS;
   (ϵᴸ!)=fill(1e-15, nsites(ψ)),
   (ϵᴿ!)=fill(1e-15, nsites(ψ)),
+  eigsolve_tol=( x -> x/100 ),
 )
+
   Nsites = nsites(ψ)
   ϵᵖʳᵉˢ = max(maximum(ϵᴸ!), maximum(ϵᴿ!))
-  krylov_tol = ϵᵖʳᵉˢ / 100
+  krylov_tol = eigsolve_tol(ϵᵖʳᵉˢ)
   ψᴴ = dag(ψ)
   ψ′ = ψᴴ'
   # XXX: make this prime the center sites
@@ -328,6 +330,7 @@ function vumps_iteration_parallel(
   ψ::InfiniteCanonicalMPS;
   (ϵᴸ!)=fill(1e-15, nsites(ψ)),
   (ϵᴿ!)=fill(1e-15, nsites(ψ)),
+  eigsolve_tol=(x -> x/100),
 )
   Nsites = nsites(ψ)
   ϵᵖʳᵉˢ = max(maximum(ϵᴸ!), maximum(ϵᴿ!))
@@ -420,7 +423,7 @@ function vumps_iteration_parallel(
 end
 
 function vumps(
-  ∑h, ψ; maxiter=10, tol=1e-8, outputlevel=1, multisite_update_alg="sequential"
+  ∑h, ψ; maxiter=10, tol=1e-8, outputlevel=1, multisite_update_alg="sequential", eigsolve_tol=( x ->x/100 ),
 )
   N = nsites(ψ)
   (ϵᴸ!) = fill(tol, nsites(ψ))
@@ -429,7 +432,7 @@ function vumps(
     println("Running VUMPS with multisite_update_alg = $multisite_update_alg")
   for iter in 1:maxiter
     ψ, (eᴸ, eᴿ) = vumps_iteration(
-      ∑h, ψ; (ϵᴸ!)=(ϵᴸ!), (ϵᴿ!)=(ϵᴿ!), multisite_update_alg=multisite_update_alg
+      ∑h, ψ; (ϵᴸ!)=(ϵᴸ!), (ϵᴿ!)=(ϵᴿ!), multisite_update_alg=multisite_update_alg, eigsolve_tol=eigsolve_tol,
     )
     ϵᵖʳᵉˢ = max(maximum(ϵᴸ!), maximum(ϵᴿ!))
     maxdimψ = maxlinkdim(ψ[0:(N + 1)])


### PR DESCRIPTION
This exposes the Krylov eigensolver tolerance `krylov_tol` as a keyword argument of the `vumps` function.