### PR TITLE
Replacing the local ITensors by MPOs in InfiniteITensorSum

### DIFF
--- a/examples/vumps/vumps_ising_extended.jl
+++ b/examples/vumps/vumps_ising_extended.jl
@@ -44,39 +44,6 @@ for j in 1:outer_iters
   ψ_0 = vumps(H, ψ_1; vumps_kwargs...)
 end
 
-function ITensors.expect(ψ::InfiniteCanonicalMPS, o, n)
-  return (noprime(ψ.AL[n] * ψ.C[n] * op(o, s[n])) * dag(ψ.AL[n] * ψ.C[n]))[]
-end
-
-function ITensors.expect(ψ::InfiniteCanonicalMPS, h::ITensor)
-  l = linkinds(only, ψ.AL)
-  r = linkinds(only, ψ.AR)
-  s = siteinds(only, ψ)
-  δˢ(n) = δ(dag(s[n]), prime(s[n]))
-  δˡ(n) = δ(l[n], prime(dag(l[n])))
-  δʳ(n) = δ(dag(r[n]), prime(r[n]))
-  ψ′ = prime(dag(ψ))
-
-  ns = sort(findsites(ψ, h))
-  nrange = ns[end] - ns[1] + 1
-  idx = 2
-  temp_O = δˡ(ns[1] - 1) * ψ.AL[ns[1]] * h * ψ′.AL[ns[1]]
-  for n in (ns[1] + 1):(ns[1] + nrange - 1)
-    if n == ns[idx]
-      temp_O = temp_O * ψ.AL[n] * ψ′.AL[n]
-      idx += 1
-    else
-      temp_O = temp_O * ψ.AL[n] * δˢ(n) * ψ′.AL[n]
-    end
-  end
-  temp_O = temp_O * ψ.C[ns[end]] * δʳ(ns[end]) * ψ′.C[ns[end]]
-  return temp_O[]
-end
-
-function ITensors.expect(ψ::InfiniteCanonicalMPS, h::InfiniteITensorSum)
-  return [expect(ψ, h[(j, j + 1)]) for j in 1:nsites(ψ)]
-end
-
 Sz = [expect(ψ_0, "Sz", n) for n in 1:N]
 energy_infinite = expect(ψ_0, H)
 

--- a/src/ITensors.jl
+++ b/src/ITensors.jl
@@ -72,6 +72,10 @@ function Base.startswith(tag::Tag, subtag::Tag)
 end
 
 function tag_starting_with(ts::TagSet, prefix)
+  x = findfirst(t -> startswith(t, Tag(prefix)), ts)
+  if isnothing(x) #in case the function is called one a link leg. Can be probably improved
+    return x
+  end
   return ts[findfirst(t -> startswith(t, Tag(prefix)), ts)]
 end
 

--- a/src/celledvectors.jl
+++ b/src/celledvectors.jl
@@ -25,16 +25,22 @@ indextagprefix() = "n="
 # Determine the cell `n` from the tag `"c=n"`
 function getcell(ts::TagSet)
   celltag = tag_starting_with(ts, celltagprefix())
+  if isnothing(celltag) #dealing with link legs
+    return celltag
+  end
   return parse(Int, celltag[(length(celltagprefix()) + 1):end])
 end
 
 function getsite(ts::TagSet)
-  celltag = ITensorInfiniteMPS.tag_starting_with(ts, indextagprefix())
+  celltag = tag_starting_with(ts, indextagprefix())
   return parse(Int, celltag[(length(indextagprefix()) + 1):end])
 end
 
 function translatecell(ts::TagSet, n::Integer)
   ncell = getcell(ts)
+  if isnothing(ncell)
+    return ts
+  end
   return replacetags(ts, celltags(ncell) => celltags(ncell + n))
 end
 
@@ -49,6 +55,7 @@ function translatecell(is::Union{<:Tuple,<:Vector}, n::Integer)
 end
 
 translatecell(T::ITensor, n::Integer) = ITensors.setinds(T, translatecell(inds(T), n))
+translatecell(T::MPO, n::Integer) = translatecell.(T, n)
 
 struct CelledVector{T} <: AbstractVector{T}
   data::Vector{T}

--- a/src/infinitecanonicalmps.jl
+++ b/src/infinitecanonicalmps.jl
@@ -115,3 +115,37 @@ function InfMPS(s::CelledVector, f::Function)
   end
   return ψ = InfiniteCanonicalMPS(ψL, ψC, ψR)
 end
+
+function ITensors.expect(ψ::InfiniteCanonicalMPS, o, n)
+  s = siteinds(only, ψ.AL)
+  return (noprime(ψ.AL[n] * ψ.C[n] * op(o, s[n])) * dag(ψ.AL[n] * ψ.C[n]))[]
+end
+
+function ITensors.expect(ψ::InfiniteCanonicalMPS, h::MPO)
+  l = linkinds(ITensorInfiniteMPS.only, ψ.AL)
+  r = linkinds(ITensorInfiniteMPS.only, ψ.AR)
+  s = siteinds(ITensorInfiniteMPS.only, ψ)
+  δˢ(n) = ITensorInfiniteMPS.δ(dag(s[n]), prime(s[n]))
+  δˡ(n) = ITensorInfiniteMPS.δ(l[n], prime(dag(l[n])))
+  δʳ(n) = ITensorInfiniteMPS.δ(dag(r[n]), prime(r[n]))
+  ψ′ = prime(dag(ψ))
+
+  ns = ITensorInfiniteMPS.findsites(ψ, h)
+  nrange = ns[end] - ns[1] + 1
+  idx = 2
+  temp_O = δˡ(ns[1] - 1) * ψ.AL[ns[1]] * ψ′.AL[ns[1]] * h[1]
+  for n in (ns[1] + 1):(ns[1] + nrange - 1)
+    if n == ns[idx]
+      temp_O = temp_O * ψ.AL[n] * ψ′.AL[n] * h[idx]
+      idx += 1
+    else
+      temp_O = temp_O * ψ.AL[n] * δˢ(n) * ψ′.AL[n]
+    end
+  end
+  temp_O = temp_O * ψ.C[ns[end]] * δʳ(ns[end]) * ψ′.C[ns[end]]
+  return temp_O[]
+end
+
+function ITensors.expect(ψ::InfiniteCanonicalMPS, h::InfiniteITensorSum)
+  return [expect(ψ, h[j]) for j in 1:nsites(ψ)]
+end

--- a/src/models/models.jl
+++ b/src/models/models.jl
@@ -24,13 +24,18 @@ end
 
 function InfiniteITensorSum(model::Model, s::CelledVector; kwargs...)
   N = length(s)
-  tensors = [ITensor(model, s, n; kwargs...) for n in 1:N] #slightly improved version. Note: the current implementation does not really allow for staggered potentials for example
-  return InfiniteITensorSum(tensors)
+  mpos = [MPO(model, s, n; kwargs...) for n in 1:N] #slightly improved version. Note: the current implementation does not really allow for staggered potentials for example
+  return InfiniteITensorSum(mpos)
+end
+
+# MPO building version
+function ITensors.MPO(model::Model, s::CelledVector, n::Int64; kwargs...)
+  n1, n2 = 1, 2
+  opsum = OpSum(model, n1, n2; kwargs...)
+  return MPO(opsum, [s[x] for x in n:(n + nrange(model) - 1)]) #modification to allow for more than two sites per term in the Hamiltonians
 end
 
 # Version accepting IndexSet
 function ITensors.ITensor(model::Model, s::CelledVector, n::Int64; kwargs...)
-  n1, n2 = 1, 2
-  opsum = OpSum(model, n1, n2; kwargs...)
-  return prod(MPO(opsum, [s[x] for x in n:(n + nrange(model) - 1)])) #modification to allow for more than two sites per term in the Hamiltonians
+  return prod(MPO(model, s, n; kwargs...)) #modification to allow for more than two sites per term in the Hamiltonians
 end

--- a/src/subspace_expansion.jl
+++ b/src/subspace_expansion.jl
@@ -45,48 +45,61 @@ function subspace_expansion(
   nL = uniqueinds(NL, ψ.AL[n1])
   nR = uniqueinds(NR, ψ.AR[n2])
   if range_H == 2
-    ψH2 = noprime(ψ.AL[n1] * H[(n1, n2)] * ψ.C[n1] * ψ.AR[n2])
+    ψH2 = noprime(ψ.AL[n1] * H[n1][1] * H[n1][2] * ψ.C[n1] * ψ.AR[n2])
   else   # Should be a better version now
     ψH2 =
-      H[(n1, n2)] * ψ.AR[n2 + range_H - 2] * ψ′.AR[n2 + range_H - 2] * δʳ(n2 + range_H - 2)
+      H[n1][end] * ψ.AR[n2 + range_H - 2] * ψ′.AR[n2 + range_H - 2] * δʳ(n2 + range_H - 2)
     common_sites = findsites(ψ, H[(n1, n2)])
     idx = length(common_sites) - 1
     for j in reverse(1:(range_H - 3))
       if n2 + j == common_sites[idx]
-        ψH2 = ψH2 * ψ.AR[n2 + j] * ψ′.AR[n2 + j]
+        ψH2 = ψH2 * ψ.AR[n2 + j] * ψ′.AR[n2 + j] * H[n1][idx]
         idx -= 1
       else
         ψH2 = ψH2 * ψ.AR[n2 + j] * δˢ(n2 + j) * ψ′.AR[n2 + j]
       end
     end
-    ψH2 = noprime(ψH2 * ψ.AL[n1] * ψ.C[n1] * ψ.AR[n2])
+    if common_sites[idx] == n2
+      ψH2 = ψH2 * ψ.AR[n2] * H[n1][idx]
+      idx -= 1
+    else
+      ψH2 = ψH2 * ψ.AR[n2] * δˢ(n2)
+    end
+    if common_sites[idx] == n1
+      ψH2 = ψH2 * ψ.AL[n1] * ψ.C[n1] * H[n1][idx]
+      idx -= 1
+    else
+      ψH2 = ψH2 * ψ.AL[n1] * ψ.C[n1] * δˢ(n1)
+    end
+
+    ψH2 = noprime(ψH2)
     for n in 1:(range_H - 2)
-      temp_H2 = H[(n1 - n, n2 - n)] * δʳ(n2 + range_H - 2 - n)
-      common_sites = findsites(ψ, H[(n1 - n, n2 - n)])
+      temp_H2 = δʳ(n2 + range_H - 2 - n)
+      common_sites = findsites(ψ, H[n1 - n])
       idx = length(common_sites)
       for j in (n2 + range_H - 2 - n):-1:(n2 + 1)
         if j == common_sites[idx]
-          temp_H2 = temp_H2 * ψ.AR[j] * ψ′.AR[j]
+          temp_H2 = temp_H2 * ψ.AR[j] * ψ′.AR[j] * H[n1 - n][idx]
           idx -= 1
         else
           temp_H2 = temp_H2 * ψ.AR[j] * ψ′.AR[j] * δˢ(j)
         end
       end
       if common_sites[idx] == n2
-        temp_H2 = temp_H2 * ψ.AR[n2]
+        temp_H2 = temp_H2 * ψ.AR[n2] * H[n1 - n][idx]
         idx -= 1
       else
         temp_H2 = temp_H2 * ψ.AR[n2] * δˢ(n2)
       end
       if common_sites[idx] == n1
-        temp_H2 = temp_H2 * ψ.AL[n1] * ψ.C[n1]
+        temp_H2 = temp_H2 * ψ.AL[n1] * ψ.C[n1] * H[n1 - n][idx]
         idx -= 1
       else
         temp_H2 = temp_H2 * ψ.AL[n1] * ψ.C[n1] * δˢ(n1)
       end
       for j in 1:n
         if n1 - j == common_sites[idx]
-          temp_H2 = temp_H2 * ψ.AL[n1 - j] * ψ′.AL[n1 - j]
+          temp_H2 = temp_H2 * ψ.AL[n1 - j] * ψ′.AL[n1 - j] * H[n1 - n][idx]
           idx -= 1
         else
           temp_H2 = temp_H2 * ψ.AL[n1 - j] * δˢ(n1 - j) * ψ′.AL[n1 - j]

--- a/src/vumps_localham.jl
+++ b/src/vumps_localham.jl
@@ -45,26 +45,31 @@ function Base.:*(H::Hᶜ, v::ITensor)
   Hᶜᴿv = v * δˡ(n) * Hᴿ[n]
   #We now start building terms where C overlap with the local Hamiltonian
   # We start with the tensor AL[n] - v - AR[n+1] ... AR[n + range_∑h - 1]
-  Hᶜʰv = v * ψ.AL[n] * δˡ(n - 1) * ψ′.AL[n] * ∑h[(n, n + 1)] #left extremity
-  common_sites = findsites(ψ, ∑h[(n, n + 1)])
+  Hᶜʰv = v * ψ.AL[n] * δˡ(n - 1) * ψ′.AL[n] * ∑h[n][1] #left extremity
+  common_sites = findsites(ψ, ∑h[n])
   idx = 2 #list the sites Σh, we start at 2 because n is already taken into account
   for k in 1:(range_∑h - 2)
     if n + k == common_sites[idx]
-      Hᶜʰv = Hᶜʰv * ψ.AR[n + k] * ψ′.AR[n + k]
+      Hᶜʰv = Hᶜʰv * ψ.AR[n + k] * ψ′.AR[n + k] * ∑h[n][idx]
       idx += 1
     else
       Hᶜʰv = Hᶜʰv * ψ.AR[n + k] * ψ′.AR[n + k] * δˢ(n + k)
     end
   end
-  Hᶜʰv = Hᶜʰv * ψ.AR[n + range_∑h - 1] * δʳ(n + range_∑h - 1) * ψ′.AR[n + range_∑h - 1]     #right most extremity
+  Hᶜʰv =
+    Hᶜʰv *
+    ψ.AR[n + range_∑h - 1] *
+    δʳ(n + range_∑h - 1) *
+    ψ′.AR[n + range_∑h - 1] *
+    ∑h[n][end]    #right most extremity
   #Now we are building contributions of the form AL[n - j] ... AL[n] - v - AR[n + 1] ... AR[n + range_∑h - 1 - j]
   for j in 1:(range_∑h - 2)
-    temp_Hᶜʰv = ψ.AL[n - j] * δˡ(n - 1 - j) * ψ′.AL[n - j] * ∑h[(n - j, n + 1 - j)]
-    common_sites = findsites(ψ, ∑h[(n - j, n + 1 - j)])
+    temp_Hᶜʰv = ψ.AL[n - j] * δˡ(n - 1 - j) * ψ′.AL[n - j] * ∑h[n - j][1]
+    common_sites = findsites(ψ, ∑h[n - j])
     idx = 2
     for k in 1:j
       if n - j + k == common_sites[idx]
-        temp_Hᶜʰv = temp_Hᶜʰv * ψ.AL[n - j + k] * ψ′.AL[n - j + k]
+        temp_Hᶜʰv = temp_Hᶜʰv * ψ.AL[n - j + k] * ψ′.AL[n - j + k] * ∑h[n - j][idx]
         idx += 1
       else
         temp_Hᶜʰv = temp_Hᶜʰv * ψ.AL[n - j + k] * ψ′.AL[n - j + k] * δˢ(n - j + k)
@@ -74,7 +79,7 @@ function Base.:*(H::Hᶜ, v::ITensor)
     temp_Hᶜʰv = temp_Hᶜʰv * v
     for k in (j + 1):(range_∑h - 2)
       if n - j + k == common_sites[idx]
-        temp_Hᶜʰv = temp_Hᶜʰv * ψ.AR[n - j + k] * ψ′.AR[n - j + k]
+        temp_Hᶜʰv = temp_Hᶜʰv * ψ.AR[n - j + k] * ψ′.AR[n - j + k] * ∑h[n - j][idx]
         idx += 1
       else
         temp_Hᶜʰv = temp_Hᶜʰv * ψ.AR[n - j + k] * ψ′.AR[n - j + k] * δˢ(n - j + k)
@@ -82,6 +87,7 @@ function Base.:*(H::Hᶜ, v::ITensor)
     end
     temp_Hᶜʰv =
       temp_Hᶜʰv *
+      ∑h[n - j][end] *
       ψ.AR[n - j + range_∑h - 1] *
       δʳ(n - j + range_∑h - 1) *
       ψ′.AR[n - j + range_∑h - 1]
@@ -117,26 +123,31 @@ function Base.:*(H::Hᴬᶜ, v::ITensor)
   Hᴬᶜᴿv = v * δˡ(n - 1) * δˢ(n) * Hᴿ[n]
   #We now start building terms where AC overlap with the local Hamiltonian
   # We start with the tensor v - AR[n+1] ... AR[n + range_∑h - 1]
-  Hᴬᶜʰv = v * δˡ(n - 1) * ∑h[(n, n + 1)]
-  common_sites = findsites(ψ, ∑h[(n, n + 1)])
-  idx = 2#list the sites Σh, we start at 2 because n is already taken into account
+  Hᴬᶜʰv = v * δˡ(n - 1) * ∑h[n][1]
+  common_sites = findsites(ψ, ∑h[n])
+  idx = 2 #list the sites Σh, we start at 2 because n is already taken into account
   for k in 1:(range_∑h - 2)
     if n + k == common_sites[idx]
-      Hᴬᶜʰv = Hᴬᶜʰv * ψ.AR[n + k] * ψ′.AR[n + k]
+      Hᴬᶜʰv = Hᴬᶜʰv * ψ.AR[n + k] * ψ′.AR[n + k] * ∑h[n][idx]
       idx += 1
     else
       Hᴬᶜʰv = Hᴬᶜʰv * ψ.AR[n + k] * ψ′.AR[n + k] * δˢ(n + k)
     end
   end
-  Hᴬᶜʰv = Hᴬᶜʰv * ψ.AR[n + range_∑h - 1] * ψ′.AR[n + range_∑h - 1] * δʳ(n + range_∑h - 1) #rightmost extremity
+  Hᴬᶜʰv =
+    Hᴬᶜʰv *
+    ∑h[n][end] *
+    ψ.AR[n + range_∑h - 1] *
+    ψ′.AR[n + range_∑h - 1] *
+    δʳ(n + range_∑h - 1) #rightmost extremity
   #Now we are building contributions of the form AL[n - j] ... AL[n-1] - v - AR[n + 1] ... AR[n + range_∑h - 1 - j]
   for j in 1:(range_∑h - 1)
-    temp_Hᴬᶜʰv = ψ.AL[n - j] * δˡ(n - j - 1) * ψ′.AL[n - j] * ∑h[(n - j, n - j + 1)]
-    common_sites = findsites(ψ, ∑h[(n - j, n - j + 1)])
+    temp_Hᴬᶜʰv = ψ.AL[n - j] * δˡ(n - j - 1) * ψ′.AL[n - j] * ∑h[n - j][1]
+    common_sites = findsites(ψ, ∑h[n - j])
     idx = 2
     for k in 1:(j - 1)
       if n - j + k == common_sites[idx]
-        temp_Hᴬᶜʰv = temp_Hᴬᶜʰv * ψ.AL[n - j + k] * ψ′.AL[n - j + k]
+        temp_Hᴬᶜʰv = temp_Hᴬᶜʰv * ψ.AL[n - j + k] * ψ′.AL[n - j + k] * ∑h[n - j][idx]
         idx += 1
       else
         temp_Hᴬᶜʰv = temp_Hᴬᶜʰv * ψ.AL[n - j + k] * ψ′.AL[n - j + k] * δˢ(n - j + k)
@@ -144,17 +155,17 @@ function Base.:*(H::Hᴬᶜ, v::ITensor)
     end
     #Finished with AL, treating the center AC = v
     if j == range_∑h - 1
-      temp_Hᴬᶜʰv = temp_Hᴬᶜʰv * v * δʳ(n - j + range_∑h - 1)
+      temp_Hᴬᶜʰv = temp_Hᴬᶜʰv * v * δʳ(n - j + range_∑h - 1) * ∑h[n - j][end]
     else
       if n == common_sites[idx] #need to check whether we need to branch v
-        temp_Hᴬᶜʰv = temp_Hᴬᶜʰv * v
+        temp_Hᴬᶜʰv = temp_Hᴬᶜʰv * v * ∑h[n - j][idx]
         idx += 1
       else
         temp_Hᴬᶜʰv = temp_Hᴬᶜʰv * v * δˢ(n)
       end
       for k in (j + 1):(range_∑h - 2)
         if n + k - j == common_sites[idx]
-          temp_Hᴬᶜʰv = temp_Hᴬᶜʰv * ψ.AR[n + k - j] * ψ′.AR[n + k - j]
+          temp_Hᴬᶜʰv = temp_Hᴬᶜʰv * ψ.AR[n + k - j] * ψ′.AR[n + k - j] * ∑h[n - j][idx]
           idx += 1
         else
           temp_Hᴬᶜʰv = temp_Hᴬᶜʰv * ψ.AR[n + k - j] * ψ′.AR[n + k - j] * δˢ(n + k - j)
@@ -162,6 +173,7 @@ function Base.:*(H::Hᴬᶜ, v::ITensor)
       end
       temp_Hᴬᶜʰv =
         temp_Hᴬᶜʰv *
+        ∑h[n - j][end] *
         ψ.AR[n + range_∑h - 1 - j] *
         ψ′.AR[n + range_∑h - 1 - j] *
         δʳ(n - j + range_∑h - 1)
@@ -225,19 +237,72 @@ function left_environment(hᴸ, 𝕙ᴸ, ψ; tol=1e-15)
   # Get the rest of the environments in the unit cell
   Hᴸ = InfiniteMPS(Vector{ITensor}(undef, N))
   Hᴸ[N] = Hᴸᴺ¹
-  #Hᴸᴺ¹ = translatecell(Hᴸᴺ¹, -1) #Found it was useless?
   for n in 1:(N - 1)
     Hᴸ[n] = Hᴸ[n - 1] * ψ.AL[n] * ψ̃.AL[n] + hᴸ[n]
   end
-  # Compute more accurate environments
-  # Not currently working
-  #for n in 1:(N - 1)
-  #  Aⁿ = Aᴸ(ψ, n)
-  #  Hᴸ[n], info = linsolve(Aⁿ, 𝕙ᴸ[n], Hᴸ[n], 1, -1; tol=tol)
-  #end
   return Hᴸ
 end
 
+function left_environment(∑h::InfiniteITensorSum, ψ::InfiniteCanonicalMPS; tol=1e-15)
+  Nsites = nsites(ψ)
+  range_∑h = nrange(∑h, 1)
+  ψᴴ = dag(ψ)
+  ψ′ = ψᴴ'
+  ψ̃ = prime(linkinds, ψᴴ)
+
+  l = linkinds(only, ψ.AL)
+  l′ = linkinds(only, ψ′.AL)
+  r = linkinds(only, ψ.AR)
+  r′ = linkinds(only, ψ′.AR)
+  s = siteinds(only, ψ)
+  δʳ(n) = δ(dag(r[n]), prime(r[n]))
+  δˡ(n) = δ(l[n], l′[n])
+  δˢ(n) = δ(dag(s[n]), prime(s[n]))
+  hᴸ = Vector{ITensor}(undef, Nsites)
+  for k in 1:Nsites
+    hᴸ[k] =
+      δˡ(k - range_∑h) *
+      ψ.AL[k - range_∑h + 1] *
+      ∑h[(k - range_∑h + 1, k - range_∑h + 2)][1] *
+      ψ′.AL[k - range_∑h + 1]
+    common_sites = findsites(ψ, ∑h[(k - range_∑h + 1, k - range_∑h + 2)])
+    idx = 2
+    for j in 2:range_∑h
+      if k - range_∑h + j == common_sites[idx]
+        hᴸ[k] =
+          hᴸ[k] *
+          ψ.AL[k - range_∑h + j] *
+          ψ′.AL[k - range_∑h + j] *
+          ∑h[(k - range_∑h + 1, k - range_∑h + 2)][idx]
+        idx += 1
+      else
+        hᴸ[k] =
+          hᴸ[k] * ψ.AL[k - range_∑h + j] * ψ′.AL[k - range_∑h + j] * δˢ(k - range_∑h + j)
+      end
+    end
+  end
+  hᴸ = InfiniteMPS(hᴸ)
+  eᴸ = [(hᴸ[k] * ψ.C[k] * δʳ(k) * ψ′.C[k])[] for k in 1:Nsites]
+  for k in 1:Nsites
+    # TODO: remove `denseblocks` once BlockSparse + DiagBlockSparse is supported
+    hᴸ[k] -= eᴸ[k] * denseblocks(δ(inds(hᴸ[k])))
+  end
+
+  𝕙ᴸ = copy(hᴸ)
+  # TODO restrict to the useful ones only?
+  for n in 1:Nsites
+    for k in 1:(Nsites - 1)
+      temp = copy(hᴸ[n - k])
+      for kp in reverse(0:(k - 1))
+        temp = temp * ψ.AL[n - kp] * ψ̃.AL[n - kp]
+      end
+      𝕙ᴸ[n] = temp + 𝕙ᴸ[n]
+    end
+  end
+  Hᴸ = left_environment(hᴸ, 𝕙ᴸ, ψ; tol=tol)
+
+  return Hᴸ, eᴸ
+end
 # Struct for use in linear system solver
 struct Aᴿ
   hᴿ::InfiniteMPS
@@ -288,6 +353,57 @@ function right_environment(hᴿ, 𝕙ᴿ, ψ; tol=1e-15)
   return Hᴿ
 end
 
+function right_environment(∑h::InfiniteITensorSum, ψ::InfiniteCanonicalMPS; tol=1e-15)
+  Nsites = nsites(ψ)
+  range_∑h = nrange(∑h, 1)
+  ψᴴ = dag(ψ)
+  ψ′ = ψᴴ'
+  ψ̃ = prime(linkinds, ψᴴ)
+
+  l = linkinds(only, ψ.AL)
+  l′ = linkinds(only, ψ′.AL)
+  r = linkinds(only, ψ.AR)
+  r′ = linkinds(only, ψ′.AR)
+  s = siteinds(only, ψ)
+  δʳ(n) = δ(dag(r[n]), prime(r[n]))
+  δˡ(n) = δ(l[n], l′[n])
+  δˢ(n) = δ(dag(s[n]), prime(s[n]))
+
+  hᴿ = Vector{ITensor}(undef, Nsites)
+  for k in 1:Nsites
+    hᴿ[k] = ψ.AR[k + range_∑h] * ∑h[k + 1][end] * ψ′.AR[k + range_∑h] * δʳ(k + range_∑h)
+    common_sites = findsites(ψ, ∑h[k + 1])
+    idx = length(common_sites) - 1
+    for j in (range_∑h - 1):-1:1
+      if k + j == common_sites[idx]
+        hᴿ[k] = hᴿ[k] * ψ.AR[k + j] * ψ′.AR[k + j] * ∑h[k + 1][idx]
+        idx -= 1
+      else
+        hᴿ[k] = hᴿ[k] * ψ.AR[k + j] * ψ′.AR[k + j] * δˢ(k + j)
+      end
+    end
+  end
+  hᴿ = InfiniteMPS(hᴿ)
+  eᴿ = [(hᴿ[k] * ψ.C[k] * δˡ(k) * ψ′.C[k])[] for k in 1:Nsites]
+  for k in 1:Nsites
+    hᴿ[k] -= eᴿ[k] * denseblocks(δ(inds(hᴿ[k])))
+  end
+
+  𝕙ᴿ = copy(hᴿ)
+  #TODO restrict to the useful ones only
+  for n in 1:Nsites
+    for k in 1:(Nsites - 1)
+      temp = copy(hᴿ[n + k])
+      for kp in reverse(1:k)
+        temp = temp * ψ.AR[n + kp] * ψ̃.AR[n + kp]
+      end
+      𝕙ᴿ[n] = temp + 𝕙ᴿ[n]
+    end
+  end
+  Hᴿ = right_environment(hᴿ, 𝕙ᴿ, ψ; tol=tol)
+  return Hᴿ, eᴿ
+end
+
 function tdvp_iteration(args...; multisite_update_alg="sequential", kwargs...)
   if multisite_update_alg == "sequential"
     return tdvp_iteration_sequential(args...; kwargs...)
@@ -300,6 +416,19 @@ function tdvp_iteration(args...; multisite_update_alg="sequential", kwargs...)
   end
 end
 
+#TODO put these functions somewhere else
+function ortho_overlap(AC, C)
+  AL, _ = polar(AC * dag(C), uniqueinds(AC, C))
+  return noprime(AL)
+end
+
+function ortho_polar(AC, C)
+  UAC, _ = polar(AC, uniqueinds(AC, C))
+  UC, _ = polar(C, commoninds(C, AC))
+  return noprime(UAC) * noprime(dag(UC))
+end
+
+#In principle, could share even more code with vumps_mpo or with parallel
 function tdvp_iteration_sequential(
   solver::Function,
   ∑h::InfiniteITensorSum,
@@ -313,18 +442,6 @@ function tdvp_iteration_sequential(
   range_∑h = nrange(∑h, 1)
   ϵᵖʳᵉˢ = max(maximum(ϵᴸ!), maximum(ϵᴿ!))
   _solver_tol = solver_tol(ϵᵖʳᵉˢ)
-  ψᴴ = dag(ψ)
-  ψ′ = ψᴴ'
-  # XXX: make this prime the center sites
-  ψ̃ = prime(linkinds, ψᴴ)
-
-  # TODO: replace with linkinds(ψ)
-  l = CelledVector([commoninds(ψ.AL[n], ψ.AL[n + 1]) for n in 1:Nsites])
-  l′ = CelledVector([commoninds(ψ′.AL[n], ψ′.AL[n + 1]) for n in 1:Nsites])
-  r = CelledVector([commoninds(ψ.AR[n], ψ.AR[n + 1]) for n in 1:Nsites])
-  r′ = CelledVector([commoninds(ψ′.AR[n], ψ′.AR[n + 1]) for n in 1:Nsites])
-  s = siteinds(only, ψ)
-  δˢ(n) = δ(dag(s[n]), prime(s[n]))
 
   ψ = copy(ψ)
   C̃ = InfiniteMPS(Vector{ITensor}(undef, Nsites))
@@ -333,97 +450,24 @@ function tdvp_iteration_sequential(
   Ãᴿ = InfiniteMPS(Vector{ITensor}(undef, Nsites))
   eᴸ = Vector{Float64}(undef, Nsites)
   eᴿ = Vector{Float64}(undef, Nsites)
+
   for n in 1:Nsites
-    # TODO improve the multisite contraction such that we contract with identities
-    hᴸ = Vector{ITensor}(undef, Nsites)
-    for k in 1:Nsites
-      hᴸ[k] =
-        δ(only(l[k - range_∑h]), only(l′[k - range_∑h])) *
-        ψ.AL[k - range_∑h + 1] *
-        ∑h[(k - range_∑h + 1, k - range_∑h + 2)] *
-        ψ′.AL[k - range_∑h + 1]
-      common_sites = findsites(ψ, ∑h[(k - range_∑h + 1, k - range_∑h + 2)])
-      idx = 2
-      for j in 2:range_∑h
-        if k - range_∑h + j == common_sites[idx]
-          hᴸ[k] = hᴸ[k] * ψ.AL[k - range_∑h + j] * ψ′.AL[k - range_∑h + j]
-          idx += 1
-        else
-          hᴸ[k] =
-            hᴸ[k] * ψ.AL[k - range_∑h + j] * ψ′.AL[k - range_∑h + j] * δˢ(k - range_∑h + j)
-        end
-      end
-    end
-    hᴸ = InfiniteMPS(hᴸ)
+    ψᴴ = dag(ψ)
+    ψ′ = ψᴴ'
+    # XXX: make this prime the center sites
+    ψ̃ = prime(linkinds, ψᴴ)
 
-    hᴿ = Vector{ITensor}(undef, Nsites)
-    for k in 1:Nsites
-      hᴿ[k] =
-        ψ.AR[k + range_∑h] *
-        ∑h[(k + 1, k + 2)] *
-        ψ′.AR[k + range_∑h] *
-        δ(only(dag(r[k + range_∑h])), only(dag(r′[k + range_∑h])))
-      common_sites = findsites(ψ, ∑h[(k + 1, k + 2)])
-      idx = length(common_sites) - 1
-      for j in (range_∑h - 1):-1:1
-        if k + j == common_sites[idx]
-          hᴿ[k] = hᴿ[k] * ψ.AR[k + j] * ψ′.AR[k + j]
-          idx -= 1
-        else
-          hᴿ[k] = hᴿ[k] * ψ.AR[k + j] * ψ′.AR[k + j] * δˢ(k + j)
-        end
-      end
-    end
-    hᴿ = InfiniteMPS(hᴿ)
-    eᴸ = [
-      (hᴸ[k] * ψ.C[k] * δ(only(dag(r[k])), only(dag(r′[k]))) * ψ′.C[k])[] for k in 1:Nsites
-    ]
-    eᴿ = [(hᴿ[k] * ψ.C[k] * δ(only(l[k]), only(l′[k])) * ψ′.C[k])[] for k in 1:Nsites]
-    for k in 1:Nsites
-      # TODO: remove `denseblocks` once BlockSparse + DiagBlockSparse is supported
-      hᴸ[k] -= eᴸ[k] * denseblocks(δ(inds(hᴸ[k])))
-      hᴿ[k] -= eᴿ[k] * denseblocks(δ(inds(hᴿ[k])))
-    end
+    l = linkinds(only, ψ.AL)
+    l′ = linkinds(only, ψ′.AL)
+    r = linkinds(only, ψ.AR)
+    r′ = linkinds(only, ψ′.AR)
+    s = siteinds(only, ψ)
+    δʳ(n) = δ(dag(r[n]), prime(r[n]))
+    δˡ(n) = δ(l[n], l′[n])
+    δˢ(n) = δ(dag(s[n]), prime(s[n]))
 
-    # TODO Promote full function?
-    function left_environment_cell(ψ, ψ̃, hᴸ)
-      Nsites = nsites(ψ)
-      𝕙ᴸ = copy(hᴸ)
-      # TODO restrict to the useful ones only?
-      for n in 1:Nsites
-        for k in 1:(Nsites - 1)
-          temp = copy(hᴸ[n - k])
-          for kp in reverse(0:(k - 1))
-            temp = temp * ψ.AL[n - kp] * ψ̃.AL[n - kp]
-          end
-          𝕙ᴸ[n] = temp + 𝕙ᴸ[n]
-        end
-      end
-      return 𝕙ᴸ
-    end
-
-    𝕙ᴸ = left_environment_cell(ψ, ψ̃, hᴸ)
-    Hᴸ = left_environment(hᴸ, 𝕙ᴸ, ψ; tol=_solver_tol)
-
-    # TODO Promote full function
-    function right_environment_cell(ψ, ψ̃, hᴿ)
-      Nsites = nsites(ψ)
-      𝕙ᴿ = copy(hᴿ)
-      # TODO restrict to the useful ones only
-      for n in 1:Nsites
-        for k in 1:(Nsites - 1)
-          temp = copy(hᴿ[n + k])
-          for kp in reverse(1:k)
-            temp = temp * ψ.AR[n + kp] * ψ̃.AR[n + kp]
-          end
-          𝕙ᴿ[n] = temp + 𝕙ᴿ[n]
-        end
-      end
-      return 𝕙ᴿ
-    end
-
-    𝕙ᴿ = right_environment_cell(ψ, ψ̃, hᴿ)
-    Hᴿ = right_environment(hᴿ, 𝕙ᴿ, ψ; tol=_solver_tol)
+    Hᴸ, eᴸ = left_environment(∑h, ψ; tol=_solver_tol)
+    Hᴿ, eᴿ = right_environment(∑h, ψ; tol=_solver_tol)
 
     Cvalsₙ₋₁, Cvecsₙ₋₁, Cinfoₙ₋₁ = solver(
       Hᶜ(∑h, Hᴸ, Hᴿ, ψ, n - 1), time_step, ψ.C[n - 1], _solver_tol
@@ -437,17 +481,6 @@ function tdvp_iteration_sequential(
     C̃[n] = Cvecsₙ
     Ãᶜ[n] = Avecsₙ
 
-    function ortho_overlap(AC, C)
-      AL, _ = polar(AC * dag(C), uniqueinds(AC, C))
-      return noprime(AL)
-    end
-
-    function ortho_polar(AC, C)
-      UAC, _ = polar(AC, uniqueinds(AC, C))
-      UC, _ = polar(C, commoninds(C, AC))
-      return noprime(UAC) * noprime(dag(UC))
-    end
-
     Ãᴸ[n] = ortho_polar(Ãᶜ[n], C̃[n])
     Ãᴿ[n] = ortho_polar(Ãᶜ[n], C̃[n - 1])
     # Update state for next iteration
@@ -456,18 +489,8 @@ function tdvp_iteration_sequential(
     ψ.AR[n] = Ãᴿ[n]
     ψ.C[n - 1] = C̃[n - 1]
     ψ.C[n] = C̃[n]
-
-    ψᴴ = dag(ψ)
-    ψ′ = ψᴴ'
-    # XXX: make this prime the center sites
-    ψ̃ = prime(linkinds, ψᴴ)
-
-    # TODO: replace with linkinds(ψ)
-    l = CelledVector([commoninds(ψ.AL[n], ψ.AL[n + 1]) for n in 1:Nsites])
-    l′ = CelledVector([commoninds(ψ′.AL[n], ψ′.AL[n + 1]) for n in 1:Nsites])
-    r = CelledVector([commoninds(ψ.AR[n], ψ.AR[n + 1]) for n in 1:Nsites])
-    r′ = CelledVector([commoninds(ψ′.AR[n], ψ′.AR[n + 1]) for n in 1:Nsites])
   end
+
   for n in 1:Nsites
     ϵᴸ![n] = norm(Ãᶜ[n] - Ãᴸ[n] * C̃[n])
     ϵᴿ![n] = norm(Ãᶜ[n] - C̃[n - 1] * Ãᴿ[n])
@@ -493,102 +516,16 @@ function tdvp_iteration_parallel(
   # XXX: make this prime the center sites
   ψ̃ = prime(linkinds, ψᴴ)
 
-  # TODO: replace with linkinds(ψ)
-  l = CelledVector([commoninds(ψ.AL[n], ψ.AL[n + 1]) for n in 1:Nsites])
-  l′ = CelledVector([commoninds(ψ′.AL[n], ψ′.AL[n + 1]) for n in 1:Nsites])
-  r = CelledVector([commoninds(ψ.AR[n], ψ.AR[n + 1]) for n in 1:Nsites])
-  r′ = CelledVector([commoninds(ψ′.AR[n], ψ′.AR[n + 1]) for n in 1:Nsites])
-
-  # TODO improve the multisite contraction such that we contract with identities
-  hᴸ = Vector{ITensor}(undef, Nsites)
-  for k in 1:Nsites
-    hᴸ[k] =
-      δ(only(l[k - range_∑h]), only(l′[k - range_∑h])) *
-      ψ.AL[k - range_∑h + 1] *
-      ∑h[(k - range_∑h + 1, k - range_∑h + 2)] *
-      ψ′.AL[k - range_∑h + 1]
-    common_sites = findsites(ψ, ∑h[(k - range_∑h + 1, k - range_∑h + 2)])
-    idx = 2
-    for j in 2:range_∑h
-      if k - range_∑h + j == common_sites[idx]
-        hᴸ[k] = hᴸ[k] * ψ.AL[k - range_∑h + j] * ψ′.AL[k - range_∑h + j]
-        idx += 1
-      else
-        hᴸ[k] =
-          hᴸ[k] * ψ.AL[k - range_∑h + j] * ψ′.AL[k - range_∑h + j] * δˢ(k - range_∑h + j)
-      end
-    end
-  end
-  hᴸ = InfiniteMPS(hᴸ)
-
-  hᴿ = Vector{ITensor}(undef, Nsites)
-  for k in 1:Nsites
-    hᴿ[k] =
-      ψ.AR[k + range_∑h] *
-      ∑h[(k + 1, k + 2)] *
-      ψ′.AR[k + range_∑h] *
-      δ(only(dag(r[k + range_∑h])), only(dag(r′[k + range_∑h])))
-    common_sites = findsites(ψ, ∑h[(k + 1, k + 2)])
-    idx = length(common_sites) - 1
-    for j in (range_∑h - 1):-1:1
-      if k + j == common_sites[idx]
-        hᴿ[k] = hᴿ[k] * ψ.AR[k + j] * ψ′.AR[k + j]
-        idx -= 1
-      else
-        hᴿ[k] = hᴿ[k] * ψ.AR[k + j] * ψ′.AR[k + j] * δˢ(k + j)
-      end
-    end
-  end
-  hᴿ = InfiniteMPS(hᴿ)
-  eᴸ = [
-    (hᴸ[k] * ψ.C[k] * δ(only(dag(r[k])), only(dag(r′[k]))) * ψ′.C[k])[] for k in 1:Nsites
-  ]
-  eᴿ = [(hᴿ[k] * ψ.C[k] * δ(only(l[k]), only(l′[k])) * ψ′.C[k])[] for k in 1:Nsites]
-  for k in 1:Nsites
-    # TODO: remove `denseblocks` once BlockSparse + DiagBlockSparse is supported
-    hᴸ[k] -= eᴸ[k] * denseblocks(δ(inds(hᴸ[k])))
-    hᴿ[k] -= eᴿ[k] * denseblocks(δ(inds(hᴿ[k])))
-  end
-
-  # TODO Promote full function?
-  function left_environment_cell(ψ, ψ̃, hᴸ)
-    Nsites = nsites(ψ)
-    𝕙ᴸ = copy(hᴸ)
-    # TODO restrict to the useful ones only?
-    for n in 1:Nsites
-      for k in 1:(Nsites - 1)
-        temp = copy(hᴸ[n - k])
-        for kp in reverse(0:(k - 1))
-          temp = temp * ψ.AL[n - kp] * ψ̃.AL[n - kp]
-        end
-        𝕙ᴸ[n] = temp + 𝕙ᴸ[n]
-      end
-    end
-    return 𝕙ᴸ
-  end
-
-  𝕙ᴸ = left_environment_cell(ψ, ψ̃, hᴸ)
-  Hᴸ = left_environment(hᴸ, 𝕙ᴸ, ψ; tol=_solver_tol)
-
-  # TODO Promote full function
-  function right_environment_cell(ψ, ψ̃, hᴿ)
-    Nsites = nsites(ψ)
-    𝕙ᴿ = copy(hᴿ)
-    # TODO restrict to the useful ones only
-    for n in 1:Nsites
-      for k in 1:(Nsites - 1)
-        temp = copy(hᴿ[n + k])
-        for kp in reverse(1:k)
-          temp = temp * ψ.AR[n + kp] * ψ̃.AR[n + kp]
-        end
-        𝕙ᴿ[n] = temp + 𝕙ᴿ[n]
-      end
-    end
-    return 𝕙ᴿ
-  end
-
-  𝕙ᴿ = right_environment_cell(ψ, ψ̃, hᴿ)
-  Hᴿ = right_environment(hᴿ, 𝕙ᴿ, ψ; tol=_solver_tol)
+  l = linkinds(only, ψ.AL)
+  l′ = linkinds(only, ψ′.AL)
+  r = linkinds(only, ψ.AR)
+  r′ = linkinds(only, ψ′.AR)
+  s = siteinds(only, ψ)
+  δʳ(n) = δ(dag(r[n]), prime(r[n]))
+  δˡ(n) = δ(l[n], l′[n])
+  δˢ(n) = δ(dag(s[n]), prime(s[n]))
+  Hᴸ, eᴸ = left_environment(∑h, ψ; tol=_solver_tol)
+  Hᴿ, eᴿ = right_environment(∑h, ψ; tol=_solver_tol)
 
   C̃ = InfiniteMPS(Vector{ITensor}(undef, Nsites))
   Ãᶜ = InfiniteMPS(Vector{ITensor}(undef, Nsites))
@@ -600,17 +537,6 @@ function tdvp_iteration_parallel(
 
     C̃[n] = Cvecsₙ
     Ãᶜ[n] = Avecsₙ
-  end
-
-  function ortho_overlap(AC, C)
-    AL, _ = polar(AC * dag(C), uniqueinds(AC, C))
-    return noprime(AL)
-  end
-
-  function ortho_polar(AC, C)
-    UAC, _ = polar(AC, uniqueinds(AC, C))
-    UC, _ = polar(C, commoninds(C, AC))
-    return noprime(UAC) * noprime(dag(UC))
   end
 
   Ãᴸ = InfiniteMPS(Vector{ITensor}(undef, Nsites))

--- a/test/test_vumps.jl
+++ b/test/test_vumps.jl
@@ -94,8 +94,8 @@ using Random
     orthogonalize!(ψfinite, nfinite + 1)
     energy2_finite = energy(ψfinite[nfinite + 1], ψfinite[nfinite + 2], hnfinite2)
 
-    energy1_infinite = energy(ψ.AL[1], ψ.AL[2] * ψ.C[2], H[(1, 2)])
-    energy2_infinite = energy(ψ.AL[2], ψ.AL[3] * ψ.C[3], H[(2, 3)])
+    energy1_infinite = energy(ψ.AL[1], ψ.AL[2] * ψ.C[2], prod(H[(1, 2)]))
+    energy2_infinite = energy(ψ.AL[2], ψ.AL[3] * ψ.C[3], prod(H[(2, 3)]))
 
     orthogonalize!(ψfinite, nfinite)
     Sz1_finite = expect(ψfinite[nfinite], "Sz")

--- a/test/test_vumps_extendedising.jl
+++ b/test/test_vumps_extendedising.jl
@@ -6,19 +6,17 @@ using Random
 @testset "vumps_extended_ising" begin
   Random.seed!(1234)
 
-  N = 2
   model = Model"ising_extended"()
   model_kwargs = (J=1.0, h=1.1, J₂=0.2)
-
-  function space_shifted(q̃sz)
-    return [QN("SzParity", 1 - q̃sz, 2) => 1, QN("SzParity", 0 - q̃sz, 2) => 1]
-  end
-
-  space_ = fill(space_shifted(1), N)
-  s = infsiteinds("S=1/2", N; space=space_)
   initstate(n) = "↑"
-  # Form the Hamiltonian
-  H = InfiniteITensorSum(model, s; model_kwargs...)
+
+  function space_shifted(::Model"ising_extended", q̃sz; conserve_qns=true)
+    if conserve_qns
+      return [QN("SzParity", 1 - q̃sz, 2) => 1, QN("SzParity", 0 - q̃sz, 2) => 1]
+    else
+      return [QN() => 2]
+    end
+  end
 
   # Compare to DMRG
   Nfinite = 100
@@ -29,39 +27,7 @@ using Random
   setmaxdim!(sweeps, 30)
   setcutoff!(sweeps, 1E-10)
   energy_finite_total, ψfinite = dmrg(Hfinite, ψfinite, sweeps; outputlevel=0)
-
-  function ITensors.expect(ψ::InfiniteCanonicalMPS, o, n)
-    return (noprime(ψ.AL[n] * ψ.C[n] * op(o, s[n])) * dag(ψ.AL[n] * ψ.C[n]))[]
-  end
-
-  function ITensors.expect(ψ::InfiniteCanonicalMPS, h::ITensor)
-    l = linkinds(ITensorInfiniteMPS.only, ψ.AL)
-    r = linkinds(ITensorInfiniteMPS.only, ψ.AR)
-    s = siteinds(ITensorInfiniteMPS.only, ψ)
-    δˢ(n) = ITensorInfiniteMPS.δ(dag(s[n]), prime(s[n]))
-    δˡ(n) = ITensorInfiniteMPS.δ(l[n], prime(dag(l[n])))
-    δʳ(n) = ITensorInfiniteMPS.δ(dag(r[n]), prime(r[n]))
-    ψ′ = prime(dag(ψ))
-
-    ns = sort(ITensorInfiniteMPS.findsites(ψ, h))
-    nrange = ns[end] - ns[1] + 1
-    idx = 2
-    temp_O = δˡ(ns[1] - 1) * ψ.AL[ns[1]] * h * ψ′.AL[ns[1]]
-    for n in (ns[1] + 1):(ns[1] + nrange - 1)
-      if n == ns[idx]
-        temp_O = temp_O * ψ.AL[n] * ψ′.AL[n]
-        idx += 1
-      else
-        temp_O = temp_O * ψ.AL[n] * δˢ(n) * ψ′.AL[n]
-      end
-    end
-    temp_O = temp_O * ψ.C[ns[end]] * δʳ(ns[end]) * ψ′.C[ns[end]]
-    return temp_O[]
-  end
-
-  function ITensors.expect(ψ::InfiniteCanonicalMPS, h::InfiniteITensorSum)
-    return [expect(ψ, h[(j, j + 1)]) for j in 1:nsites(ψ)]
-  end
+  Szs_finite = expect(ψfinite, "Sz")
 
   function energy(ψ, h, n)
     ϕ = ψ[n] * ψ[n + 1] * ψ[n + 2]
@@ -80,37 +46,43 @@ using Random
   tol = 1e-8
   maxiter = 20
   outer_iters = 4
-  for multisite_update_alg in ["sequential", "parallel"]
+  for multisite_update_alg in ["sequential"],# "parallel"],
+    conserve_qns in [true],# false],
+    nsites in [1, 2],
+    time_step in [-Inf, -0.5]
+
     vumps_kwargs = (
-      multisite_update_alg=multisite_update_alg, tol=tol, maxiter=maxiter, outputlevel=0
+      multisite_update_alg=multisite_update_alg,
+      tol=tol,
+      maxiter=maxiter,
+      outputlevel=0,
+      time_step=time_step,
     )
     subspace_expansion_kwargs = (cutoff=cutoff, maxdim=maxdim)
 
-    #
-    # Alternate steps of running VUMPS and increasing the bond dimension
+    space_ = fill(space_shifted(model, 1; conserve_qns=conserve_qns), nsites)
+    s = infsiteinds("S=1/2", nsites; space=space_)
+    H = InfiniteITensorSum(model, s; model_kwargs...)
     ψ = InfMPS(s, initstate)
 
     # Check translational invariance
-    @test contract(ψ.AL[1:N]..., ψ.C[N]) ≈ contract(ψ.C[0], ψ.AR[1:N]...)
+    @test contract(ψ.AL[1:nsites]..., ψ.C[nsites]) ≈ contract(ψ.C[0], ψ.AR[1:nsites]...)
 
-    ψ = vumps(H, ψ; vumps_kwargs...)
+    ψ = tdvp(H, ψ; vumps_kwargs...)
     for _ in 1:outer_iters
       ψ = subspace_expansion(ψ, H; subspace_expansion_kwargs...)
-      ψ = vumps(H, ψ; vumps_kwargs...)
+      ψ = tdvp(H, ψ; vumps_kwargs...)
     end
-
     # Check translational invariance
-    @test norm(contract(ψ.AL[1:N]..., ψ.C[N]) - contract(ψ.C[0], ψ.AR[1:N]...)) ≈ 0 atol =
-      1e-5
+    @test norm(
+      contract(ψ.AL[1:nsites]..., ψ.C[nsites]) - contract(ψ.C[0], ψ.AR[1:nsites]...)
+    ) ≈ 0 atol = 1e-5
 
     energy_infinite = expect(ψ, H)
-    Sz1_finite, Sz2_finite = expect(ψfinite, "Sz")[(Nfinite ÷ 2):(Nfinite ÷ 2 + 1)]
-    Sz1_infinite, Sz2_infinite = [expect(ψ, "Sz", n) for n in 1:N]
+    Szs_infinite = [expect(ψ, "Sz", n) for n in 1:nsites]
 
-    @test energy_finite ≈ sum(energy_infinite) / N rtol = 1e-4
-    @test Sz1_finite ≈ Sz1_infinite rtol = 1e-3
-    @test Sz1_finite ≈ Sz2_finite rtol = 1e-5
-    @test Sz1_infinite ≈ Sz2_infinite rtol = 1e-5
+    @test energy_finite ≈ sum(energy_infinite) / nsites rtol = 1e-4
+    @test Szs_finite[nfinite:(nfinite + nsites - 1)] ≈ Szs_infinite rtol = 1e-3
   end
 end
 


### PR DESCRIPTION
Replace the ITensor in InfiniteITensorSum by a MPO.
The change is completely transparent from the user point of view.

Improved the tests on the extended Ising (slows down the testing quite significantly).

Improve the shared code in vumps_localham.jl

I might be interesting to check there are no significant performance regression. It did not seem to be the case in my testing.