### PR TITLE
More VUMPS optimizations

### DIFF
--- a/src/vumps_nonlocalham.jl
+++ b/src/vumps_nonlocalham.jl
@@ -14,18 +14,27 @@ function Base.:*(H::Hᶜ{MPO}, v::ITensor)
   r′ = linkinds(only, ψ′.AR)
   s = siteinds(only, ψ)
   s′ = siteinds(only, ψ′)
-  δˢ(n) = δ(dag(s[n]), prime(s[n]))
-  δʳ(n) = δ(dag(r[n]), prime(r[n]))
-  δˡ(n) = δ(l[n], l′[n])
+
+  # Remove temporarily in favor of `replaceinds`,
+  # which is more efficient.
+  # δˢ(n) = δ(dag(s[n]), prime(s[n]))
+  # δʳ(n) = δ(dag(r[n]), prime(r[n]))
+  # δˡ(n) = δ(l[n], l′[n])
 
   #Build the contribution of the left environment
-  Hᶜᴸv = v * Hᴸ[n] * δʳ(n)
+  # Hᶜᴸv = v * Hᴸ[n] * δʳ(n)
+  Hᶜᴸv = replaceinds(v * Hᴸ[n], r[n] => r[n]')
   #Build the contribution of the right environment
-  Hᶜᴿv = v * δˡ(n) * Hᴿ[n]
+  # Hᶜᴿv = v * δˡ(n) * Hᴿ[n]
+  Hᶜᴿv = replaceinds(v, l[n] => l[n]') * Hᴿ[n]
   #We now start building terms where C overlap with the local Hamiltonian
   # We start with the tensor AL[n] - v - AR[n+1] ... AR[n + range_∑h - 1]
+  # Hᶜʰv =
+  #   δʳ(n + range_∑h - 1) * ψ.AR[n + range_∑h - 1] * ∑h[n][end] * ψ′.AR[n + range_∑h - 1]
   Hᶜʰv =
-    δʳ(n + range_∑h - 1) * ψ.AR[n + range_∑h - 1] * ∑h[n][end] * ψ′.AR[n + range_∑h - 1]
+    replaceinds(ψ.AR[n + range_∑h - 1], r[n + range_∑h - 1] => r[n + range_∑h - 1]') *
+    ∑h[n][end] *
+    ψ′.AR[n + range_∑h - 1]
   common_sites = findsites(ψ, ∑h[n])
   idx = length(∑h[n]) - 1 #list the sites Σh, we start at 2 because n is already taken into account
   for k in reverse(1:(range_∑h - 2))
@@ -33,13 +42,17 @@ function Base.:*(H::Hᶜ{MPO}, v::ITensor)
       Hᶜʰv = Hᶜʰv * ψ.AR[n + k] * ∑h[n][idx] * ψ′.AR[n + k]
       idx -= 1
     else
-      Hᶜʰv = Hᶜʰv * ψ.AR[n + k] * δˢ(n + k) * ψ′.AR[n + k]
+      # Hᶜʰv = Hᶜʰv * ψ.AR[n + k] * δˢ(n + k) * ψ′.AR[n + k]
+      Hᶜʰv = replaceinds(Hᶜʰv * ψ.AR[n + k], s[n + k] => s[n + k]') * ψ′.AR[n + k]
     end
   end
-  Hᶜʰv = v * ψ.AL[n] * δˡ(n - 1) * ∑h[n][1] * ψ′.AL[n] * Hᶜʰv #left extremity
+  # Hᶜʰv = v * ψ.AL[n] * δˡ(n - 1) * ∑h[n][1] * ψ′.AL[n] * Hᶜʰv #left extremity
+  Hᶜʰv = replaceinds(v * ψ.AL[n], l[n - 1] => l[n - 1]') * ∑h[n][1] * ψ′.AL[n] * Hᶜʰv #left extremity
   #Now we are building contributions of the form AL[n - j] ... AL[n] - v - AR[n + 1] ... AR[n + range_∑h - 1 - j]
   for j in 1:(range_∑h - 2)
-    temp_Hᶜʰv = ψ.AL[n - j] * δˡ(n - 1 - j) * ∑h[n - j][1] * ψ′.AL[n - j]
+    # temp_Hᶜʰv = ψ.AL[n - j] * δˡ(n - 1 - j) * ∑h[n - j][1] * ψ′.AL[n - j]
+    temp_Hᶜʰv =
+      replaceinds(ψ.AL[n - j], l[n - 1 - j] => l[n - 1 - j]') * ∑h[n - j][1] * ψ′.AL[n - j]
     common_sites = findsites(ψ, ∑h[n - j])
     idx = 2
     for k in 1:j
@@ -47,29 +60,42 @@ function Base.:*(H::Hᶜ{MPO}, v::ITensor)
         temp_Hᶜʰv = temp_Hᶜʰv * ψ.AL[n - j + k] * ∑h[n - j][idx] * ψ′.AL[n - j + k]
         idx += 1
       else
-        temp_Hᶜʰv = temp_Hᶜʰv * ψ.AL[n - j + k] * δˢ(n - j + k) * ψ′.AL[n - j + k]
+        # temp_Hᶜʰv = temp_Hᶜʰv * ψ.AL[n - j + k] * δˢ(n - j + k) * ψ′.AL[n - j + k]
+        temp_Hᶜʰv =
+          replaceinds(temp_Hᶜʰv * ψ.AL[n - j + k], s[n - j + k] => s[n - j + k]') *
+          ψ′.AL[n - j + k]
       end
     end
     # Finished the AL part
-    temp_Hᶜʰv = temp_Hᶜʰv * v
-    for k in (j + 1):(range_∑h - 2)
-      if n - j + k == common_sites[idx]
-        temp_Hᶜʰv = temp_Hᶜʰv * ψ.AR[n - j + k] * ∑h[n - j][idx] * ψ′.AR[n - j + k]
-        idx += 1
-      else
-        temp_Hᶜʰv = temp_Hᶜʰv * ψ.AR[n - j + k] * δˢ(n - j + k) * ψ′.AR[n - j + k]
-      end
-    end
-    temp_Hᶜʰv =
-      temp_Hᶜʰv *
-      ψ.AR[n - j + range_∑h - 1] *
-      δʳ(n - j + range_∑h - 1) *
+    # temp_Hᶜʰv_r =
+    #   ψ.AR[n - j + range_∑h - 1] *
+    #   δʳ(n - j + range_∑h - 1) *
+    #   ∑h[n - j][end] *
+    #   ψ′.AR[n - j + range_∑h - 1]
+    temp_Hᶜʰv_r =
+      replaceinds(
+        ψ.AR[n - j + range_∑h - 1], r[n - j + range_∑h - 1] => r[n - j + range_∑h - 1]'
+      ) *
       ∑h[n - j][end] *
       ψ′.AR[n - j + range_∑h - 1]
+    idx = length(∑h[n]) - 1
+    for k in reverse((j + 1):(range_∑h - 2))
+      if n - j + k == common_sites[idx]
+        temp_Hᶜʰv_r = temp_Hᶜʰv_r * ψ.AR[n - j + k] * ∑h[n - j][idx] * ψ′.AR[n - j + k]
+        idx -= 1
+      else
+        # temp_Hᶜʰv_r = temp_Hᶜʰv_r * ψ.AR[n - j + k] * δˢ(n - j + k) * ψ′.AR[n - j + k]
+        temp_Hᶜʰv_r =
+          replaceinds(temp_Hᶜʰv_r * ψ.AR[n - j + k], s[n - j + k] => s[n - j + k]') *
+          ψ′.AR[n - j + k]
+      end
+    end
+    temp_Hᶜʰv = temp_Hᶜʰv * v * temp_Hᶜʰv_r
     Hᶜʰv = Hᶜʰv + temp_Hᶜʰv
   end
   Hᶜv = Hᶜᴸv + Hᶜʰv + Hᶜᴿv
-  return Hᶜv * dag(δˡ(n)) * dag(δʳ(n))
+  # return Hᶜv * dag(δˡ(n)) * dag(δʳ(n))
+  return replaceinds(Hᶜv, (l[n], r[n]) => (l[n]', r[n]'))
 end
 
 function Base.:*(H::Hᴬᶜ{MPO}, v::ITensor)
@@ -88,9 +114,11 @@ function Base.:*(H::Hᴬᶜ{MPO}, v::ITensor)
   s = siteinds(only, ψ)
   s′ = siteinds(only, ψ′)
 
-  δˢ(n) = δ(dag(s[n]), prime(s[n]))
-  δʳ(n) = δ(dag(r[n]), prime(r[n]))
-  δˡ(n) = δ(l[n], l′[n])
+  # Remove temporarily in favor of `replaceinds`,
+  # which is more efficient.
+  # δˢ(n) = δ(dag(s[n]), prime(s[n]))
+  # δʳ(n) = δ(dag(r[n]), prime(r[n]))
+  # δˡ(n) = δ(l[n], l′[n])
 
   #Contribution of the left environment
   # Hᴬᶜᴸv = v * Hᴸ[n - 1] * δˢ(n) * δʳ(n)
@@ -103,7 +131,9 @@ function Base.:*(H::Hᴬᶜ{MPO}, v::ITensor)
   # Hᴬᶜʰv =
   #   δʳ(n + range_∑h - 1) * ψ.AR[n + range_∑h - 1] * ∑h[n][end] * ψ′.AR[n + range_∑h - 1] #rightmost extremity
   Hᴬᶜʰv =
-    replaceinds(ψ.AR[n + range_∑h - 1], r[n + range_∑h - 1] => r[n + range_∑h - 1]') * ∑h[n][end] * ψ′.AR[n + range_∑h - 1] #rightmost extremity
+    replaceinds(ψ.AR[n + range_∑h - 1], r[n + range_∑h - 1] => r[n + range_∑h - 1]') *
+    ∑h[n][end] *
+    ψ′.AR[n + range_∑h - 1] #rightmost extremity
   common_sites = findsites(ψ, ∑h[n])
   idx = length(∑h[n]) - 1  #list the sites Σh, we start at 2 because n is already taken into account
   for k in reverse(1:(range_∑h - 2))
@@ -120,7 +150,8 @@ function Base.:*(H::Hᴬᶜ{MPO}, v::ITensor)
   #Now we are building contributions of the form AL[n - j] ... AL[n-1] - v - AR[n + 1] ... AR[n + range_∑h - 1 - j]
   for j in 1:(range_∑h - 1)
     # temp_Hᴬᶜʰv = ψ.AL[n - j] * δˡ(n - j - 1) * ∑h[n - j][1] * ψ′.AL[n - j]
-    temp_Hᴬᶜʰv = replaceinds(ψ.AL[n - j], l[n - j - 1] => l[n - j - 1]') * ∑h[n - j][1] * ψ′.AL[n - j]
+    temp_Hᴬᶜʰv =
+      replaceinds(ψ.AL[n - j], l[n - j - 1] => l[n - j - 1]') * ∑h[n - j][1] * ψ′.AL[n - j]
     common_sites = findsites(ψ, ∑h[n - j])
     idx = 2
     for k in 1:(j - 1)
@@ -129,13 +160,17 @@ function Base.:*(H::Hᴬᶜ{MPO}, v::ITensor)
         idx += 1
       else
         # temp_Hᴬᶜʰv = temp_Hᴬᶜʰv * ψ.AL[n - j + k] * δˢ(n - j + k) * ψ′.AL[n - j + k]
-        temp_Hᴬᶜʰv = replaceinds(temp_Hᴬᶜʰv * ψ.AL[n - j + k], s[n - j + k] => s[n - j + k]') * ψ′.AL[n - j + k]
+        temp_Hᴬᶜʰv =
+          replaceinds(temp_Hᴬᶜʰv * ψ.AL[n - j + k], s[n - j + k] => s[n - j + k]') *
+          ψ′.AL[n - j + k]
       end
     end
     #Finished with AL, treating the center AC = v
     if j == range_∑h - 1
       # temp_Hᴬᶜʰv = temp_Hᴬᶜʰv * v * ∑h[n - j][end] * δʳ(n - j + range_∑h - 1)
-      temp_Hᴬᶜʰv = replaceinds(temp_Hᴬᶜʰv * v * ∑h[n - j][end], r[n - j + range_∑h - 1] => r[n - j + range_∑h - 1]')
+      temp_Hᴬᶜʰv = replaceinds(
+        temp_Hᴬᶜʰv * v * ∑h[n - j][end], r[n - j + range_∑h - 1] => r[n - j + range_∑h - 1]'
+      )
     else
       # temp_Hᴬᶜʰv_r =
       #   ψ.AR[n + range_∑h - 1 - j] *
@@ -143,7 +178,9 @@ function Base.:*(H::Hᴬᶜ{MPO}, v::ITensor)
       #   ∑h[n - j][end] *
       #   ψ′.AR[n + range_∑h - 1 - j]
       temp_Hᴬᶜʰv_r =
-        replaceinds(ψ.AR[n + range_∑h - 1 - j], r[n - j + range_∑h - 1] => r[n - j + range_∑h - 1]') *
+        replaceinds(
+          ψ.AR[n + range_∑h - 1 - j], r[n - j + range_∑h - 1] => r[n - j + range_∑h - 1]'
+        ) *
         ∑h[n - j][end] *
         ψ′.AR[n + range_∑h - 1 - j]
 
@@ -154,7 +191,9 @@ function Base.:*(H::Hᴬᶜ{MPO}, v::ITensor)
           idx -= 1
         else
           # temp_Hᴬᶜʰv_r = temp_Hᴬᶜʰv_r * ψ.AR[n + k - j] * δˢ(n + k - j) * ψ′.AR[n + k - j]
-          temp_Hᴬᶜʰv_r = replaceinds(temp_Hᴬᶜʰv_r * ψ.AR[n + k - j], s[n + k - j] => s[n + k - j]') * ψ′.AR[n + k - j]
+          temp_Hᴬᶜʰv_r =
+            replaceinds(temp_Hᴬᶜʰv_r * ψ.AR[n + k - j], s[n + k - j] => s[n + k - j]') *
+            ψ′.AR[n + k - j]
         end
       end
 

--- a/src/vumps_nonlocalham.jl
+++ b/src/vumps_nonlocalham.jl
@@ -137,32 +137,33 @@ function Base.:*(H::Hᴬᶜ{MPO}, v::ITensor)
       # temp_Hᴬᶜʰv = temp_Hᴬᶜʰv * v * ∑h[n - j][end] * δʳ(n - j + range_∑h - 1)
       temp_Hᴬᶜʰv = replaceinds(temp_Hᴬᶜʰv * v * ∑h[n - j][end], r[n - j + range_∑h - 1] => r[n - j + range_∑h - 1]')
     else
-      if n == common_sites[idx] #need to check whether we need to branch v
-        temp_Hᴬᶜʰv = temp_Hᴬᶜʰv * v * ∑h[n - j][idx]
-        idx += 1
-      else
-        # temp_Hᴬᶜʰv = temp_Hᴬᶜʰv * v * δˢ(n)
-        temp_Hᴬᶜʰv = replaceinds(temp_Hᴬᶜʰv * v, s[n] => s[n]')
-      end
-      for k in (j + 1):(range_∑h - 2)
-        if n + k - j == common_sites[idx]
-          temp_Hᴬᶜʰv = temp_Hᴬᶜʰv * ψ.AR[n + k - j] * ∑h[n - j][idx] * ψ′.AR[n + k - j]
-          idx += 1
-        else
-          # temp_Hᴬᶜʰv = temp_Hᴬᶜʰv * ψ.AR[n + k - j] * δˢ(n + k - j) * ψ′.AR[n + k - j]
-          temp_Hᴬᶜʰv = replaceinds(temp_Hᴬᶜʰv * ψ.AR[n + k - j], s[n + k - j] => s[n + k - j]') * ψ′.AR[n + k - j]
-        end
-      end
-      # temp_Hᴬᶜʰv =
-      #   temp_Hᴬᶜʰv *
+      # temp_Hᴬᶜʰv_r =
       #   ψ.AR[n + range_∑h - 1 - j] *
       #   δʳ(n - j + range_∑h - 1) *
       #   ∑h[n - j][end] *
       #   ψ′.AR[n + range_∑h - 1 - j]
-      temp_Hᴬᶜʰv =
-        replaceinds(temp_Hᴬᶜʰv * ψ.AR[n + range_∑h - 1 - j], r[n - j + range_∑h - 1] => r[n - j + range_∑h - 1]') *
+      temp_Hᴬᶜʰv_r =
+        replaceinds(ψ.AR[n + range_∑h - 1 - j], r[n - j + range_∑h - 1] => r[n - j + range_∑h - 1]') *
         ∑h[n - j][end] *
         ψ′.AR[n + range_∑h - 1 - j]
+
+      idx = length(∑h[n]) - 1
+      for k in reverse((j + 1):(range_∑h - 2))
+        if n + k - j == common_sites[idx]
+          temp_Hᴬᶜʰv_r = temp_Hᴬᶜʰv_r * ψ.AR[n + k - j] * ∑h[n - j][idx] * ψ′.AR[n + k - j]
+          idx -= 1
+        else
+          # temp_Hᴬᶜʰv_r = temp_Hᴬᶜʰv_r * ψ.AR[n + k - j] * δˢ(n + k - j) * ψ′.AR[n + k - j]
+          temp_Hᴬᶜʰv_r = replaceinds(temp_Hᴬᶜʰv_r * ψ.AR[n + k - j], s[n + k - j] => s[n + k - j]') * ψ′.AR[n + k - j]
+        end
+      end
+
+      if n == common_sites[idx] #need to check whether we need to branch v
+        temp_Hᴬᶜʰv = temp_Hᴬᶜʰv * v * ∑h[n - j][idx] * temp_Hᴬᶜʰv_r
+      else
+        # temp_Hᴬᶜʰv = temp_Hᴬᶜʰv * v * δˢ(n) * temp_Hᴬᶜʰv_r
+        temp_Hᴬᶜʰv = replaceinds(temp_Hᴬᶜʰv * v * temp_Hᴬᶜʰv_r, s[n] => s[n]')
+      end
     end
     Hᴬᶜʰv = Hᴬᶜʰv + temp_Hᴬᶜʰv
   end


### PR DESCRIPTION
This adds more optimizations along the lines of #64.

#64 only fixed the contraction sequence for computing the first MPO in the unit cell of the `InfiniteSum{MPO}` when computing matrix-vector multiplications of the effective Hamiltonian for `AC` and `C`. This fixes the contraction sequence of the rest of the MPOs.

Also, it temporarily replaces delta contractions with calls to `replaceinds`, which are more efficient since they avoid copying.

For the same example shown in #64, the new timings are:
```julia
Run VUMPS with new bond dimension
Using VUMPS solver with time step -Inf
Running VUMPS with multisite_update_alg = sequential
VUMPS iteration 1 (out of maximum 100). Bond dimension = 64, energy = ([-1.250843628949261, -1.2508436289529712, -1.2508436289615772], [-1.2508436289474274, -1.2508436289914866, -1.2508436289599272]), ϵᵖʳᵉˢ = 1.3059781896512132e-9, tol = 1.0e-6
Precision error 1.3059781896512132e-9 reached tolerance 1.0e-6, stopping VUMPS after 1 iterations (of a maximum 100).
  0.215803 seconds (2.47 M allocations: 409.423 MiB, 10.52% gc time)
  5.427232 seconds (61.22 M allocations: 8.782 GiB, 13.43% gc time)
```