### PR TITLE
InfiniteMPOMatrix -> InfiniteMPO conversion

### DIFF
--- a/src/infinitempo.jl
+++ b/src/infinitempo.jl
@@ -11,3 +11,5 @@ mutable struct InfiniteMPO <: AbstractInfiniteMPS
 end
 
 translator(mpo::InfiniteMPO) = mpo.data.translator
+
+InfiniteMPO(data::CelledVector{ITensor}) = InfiniteMPO(data, 0, size(data, 1), false)

--- a/src/infinitempomatrix.jl
+++ b/src/infinitempomatrix.jl
@@ -60,53 +60,53 @@ end
 #  This code should be 100% dense/blocks-sparse agnostic.
 #
 function matrixITensorToITensor(Hm::Matrix{ITensor})::ITensor
-  indexT=typeof(inds(Hm[1,1])[1])
-  T=eltype(Hm[1,1])
+  indexT = typeof(inds(Hm[1, 1])[1])
+  T = eltype(Hm[1, 1])
   lx, ly = size(Hm)
-  @assert lx==ly
+  @assert lx == ly
   #
   #  Extract the sub diagonal
   #
-  Ms=map(n->Hm[lx-n+1,ly-n],1:lx-1) #Get the sub diagonal into an array.
-  N=length(Ms)
-  @assert N==lx-1
+  Ms = map(n -> Hm[lx - n + 1, ly - n], 1:(lx - 1)) #Get the sub diagonal into an array.
+  N = length(Ms)
+  @assert N == lx - 1
   #
   #  We need a dummy link index, but it has to have the right direction.  
   #  Ms[1] should only have one link index which should be pointing to the right.
   #
-  @assert length(inds(Ms[1],tags="Link"))==1
-  ir,=inds(Ms[1],tags="Link")
-  il0=Index(ITensors.trivial_space(ir);dir=dir(dag(ir)),tags="Link,l=0") #Dw=1 left dummy index.
+  @assert length(inds(Ms[1]; tags="Link")) == 1
+  ir, = inds(Ms[1]; tags="Link")
+  il0 = Index(ITensors.trivial_space(ir); dir=dir(dag(ir)), tags="Link,l=0") #Dw=1 left dummy index.
   #
   # Convert edge Ms to order 4 ITensors using the dummy index.
   #
-  Ms[1]*=onehot(T, il0 => 1)
-  Ms[N]*=onehot(T, dag(il0) => 1) #We don't need distinct index IDs for this.  directsum makes all new index anyway.
+  Ms[1] *= onehot(T, il0 => 1)
+  Ms[N] *= onehot(T, dag(il0) => 1) #We don't need distinct index IDs for this.  directsum makes all new index anyway.
   #
   #  Create list of all left and right link indices on the Ms.  In order to support dense storage we 
   #  can't use QN directions to decide left/right.  Instead we look for common tags among the neighbouring Ms.
   #  Right now the code assumes plev=0 for all Ms.
   #
-  is=NTuple{2,indexT}[]
-  ir=il0 #set up recursion below.  ir is from the previous M, should have the same tags as il on the next M.
+  is = NTuple{2,indexT}[]
+  ir = il0 #set up recursion below.  ir is from the previous M, should have the same tags as il on the next M.
   for n in 1:N
-    il,=inds(Ms[n],tags=tags(ir)) #Find the left index
-    ir=noncommonind(Ms[n],il,tags="Link") #Find the new right index by elimination
-    push!(is,(il,ir))    
-  end 
+    il, = inds(Ms[n]; tags=tags(ir)) #Find the left index
+    ir = noncommonind(Ms[n], il; tags="Link") #Find the new right index by elimination
+    push!(is, (il, ir))
+  end
   #
   # Now direct sum everything non-empty in Hm, including those I ops in the corners.
   # Order is critical.   
   # Details of the Link index tags like "l=n" do not matter from here on.
   #
-  H=Hm[1,1]*onehot(T, il0' => 1)*onehot(T, dag(il0) => 1) #Bootstrap with the I op in the top left of Hm
-  H,ih=directsum(H=>il0',Ms[N]=>is[N][1]) #1-D directsum to put M[N] directly below the I op
-  ih=ih,dag(il0) #setup recusion.
-  for i in N-1:-1:1 #2-D directsums to place new blocks below and to the right.
-      H,ih=directsum(H=>ih,Ms[i]=>is[i],tags=["Link,left","Link,right"]) 
+  H = Hm[1, 1] * onehot(T, il0' => 1) * onehot(T, dag(il0) => 1) #Bootstrap with the I op in the top left of Hm
+  H, ih = directsum(H => il0', Ms[N] => is[N][1]) #1-D directsum to put M[N] directly below the I op
+  ih = ih, dag(il0) #setup recusion.
+  for i in (N - 1):-1:1 #2-D directsums to place new blocks below and to the right.
+    H, ih = directsum(H => ih, Ms[i] => is[i]; tags=["Link,left", "Link,right"])
   end
-  IN=Hm[N+1,N+1]*onehot(T, dag(il0) => 1)*onehot(T, ih[1] => dim(ih[1])) #I op in the bottom left of Hm
-  H,_=directsum(H=>ih[2],IN=>il0,tags="Link,right") #1-D directsum to the put I in the bottom row, to the right of M[1]
+  IN = Hm[N + 1, N + 1] * onehot(T, dag(il0) => 1) * onehot(T, ih[1] => dim(ih[1])) #I op in the bottom left of Hm
+  H, _ = directsum(H => ih[2], IN => il0; tags="Link,right") #1-D directsum to the put I in the bottom row, to the right of M[1]
   return H
 end
 #
@@ -117,8 +117,8 @@ end
 function InfiniteMPO(Hm::InfiniteMPOMatrix)
   Hs = matrixITensorToITensor.(data(Hm))
   Hi = CelledVector([H for H in Hs], translator(Hm))
-  lis = CelledVector([inds(H,tags="left")[1] for H in Hs], translator(Hm))
-  ris = CelledVector([inds(H,tags="right")[1] for H in Hs], translator(Hm))
+  lis = CelledVector([inds(H; tags="left")[1] for H in Hs], translator(Hm))
+  ris = CelledVector([inds(H; tags="right")[1] for H in Hs], translator(Hm))
   site_inds = [commoninds(Hm[j][1, 1], Hm[j][end, end])[1] for j in 1:nsites(Hm)]
   #
   #  Create new tags with proper cell and link numbers.  Also daisy chain
@@ -128,7 +128,7 @@ function InfiniteMPO(Hm::InfiniteMPOMatrix)
     newTag = "Link,c=$(getcell(site_inds[j])),l=$(getsite(site_inds[j]))"
     ir = replacetags(ris[j], tags(ris[j]), newTag) #new right index
     Hi[j] = replaceinds(Hi[j], [ris[j]], [ir])
-    Hi[j + 1] = replaceinds(Hi[j + 1],[lis[j + 1]],[dag(ir)])
+    Hi[j + 1] = replaceinds(Hi[j + 1], [lis[j + 1]], [dag(ir)])
   end
   return InfiniteMPO(Hi)
 end

--- a/src/infinitempomatrix.jl
+++ b/src/infinitempomatrix.jl
@@ -7,6 +7,7 @@ mutable struct InfiniteMPOMatrix <: AbstractInfiniteMPS
 end
 
 translator(mpo::InfiniteMPOMatrix) = mpo.data.translator
+data(mpo::InfiniteMPOMatrix) = mpo.data
 
 # TODO better printing?
 function Base.show(io::IO, M::InfiniteMPOMatrix)
@@ -43,4 +44,91 @@ function InfiniteMPOMatrix(data::Vector{Matrix{ITensor}}, translator::Function)
   return InfiniteMPOMatrix(CelledVector(data, translator), 0, size(data)[1], false)
 end
 
-#nrange(H::InfiniteMPOMatrix) = [size(H[j])[1] - 1 for j in 1:nsites(H)]
+#
+#  Hm should have the form below.  Only link indices are shown.
+#
+#    I         0                     0           0      0
+#  M-->l=n     0                     0           0      0
+#    0    l=n-->M-->l=n-1 ...        0           0      0
+#    :         :                     :           :      :
+#    0         0          ...  l=2-->M-->l=1     0      0
+#    0         0          ...        0        l=1-->M   I
+#
+#  We need to capture the corner I's and the sub-diagonal Ms, and paste them together into an ITensor.
+#  This is facilutated by making all elements of Hm into order(4) tensors by adding dummy Dw=1 indices.
+#  We ITensors.directsum() to join all the blocks into the final ITensor.
+#  This code should be 100% dense/blocks-sparse agnostic.
+#
+function matrixITensorToITensor(Hm::Matrix{ITensor})::ITensor
+  indexT=typeof(inds(Hm[1,1])[1])
+  T=eltype(Hm[1,1])
+  lx, ly = size(Hm)
+  @assert lx==ly
+  #
+  #  Extract the sub diagonal
+  #
+  Ms=map(n->Hm[lx-n+1,ly-n],1:lx-1) #Get the sub diagonal into an array.
+  N=length(Ms)
+  @assert N==lx-1
+  #
+  #  We need a dummy link index, but it has to have the right direction.  
+  #  Ms[1] should only have one link index which should be pointing to the right.
+  #
+  @assert length(inds(Ms[1],tags="Link"))==1
+  ir,=inds(Ms[1],tags="Link")
+  il0=Index(ITensors.trivial_space(ir);dir=dir(dag(ir)),tags="Link,l=0") #Dw=1 left dummy index.
+  #
+  # Convert edge Ms to order 4 ITensors using the dummy index.
+  #
+  Ms[1]*=onehot(T, il0 => 1)
+  Ms[N]*=onehot(T, dag(il0) => 1) #We don't need distinct index IDs for this.  directsum makes all new index anyway.
+  #
+  #  Create list of all left and right link indices on the Ms.  In order to support dense storage we 
+  #  can't use QN directions to decide left/right.  Instead we look for common tags among the neighbouring Ms.
+  #  Right now the code assumes plev=0 for all Ms.
+  #
+  is=NTuple{2,indexT}[]
+  ir=il0 #set up recursion below.  ir is from the previous M, should have the same tags as il on the next M.
+  for n in 1:N
+    il,=inds(Ms[n],tags=tags(ir)) #Find the left index
+    ir=noncommonind(Ms[n],il,tags="Link") #Find the new right index by elimination
+    push!(is,(il,ir))    
+  end 
+  #
+  # Now direct sum everything non-empty in Hm, including those I ops in the corners.
+  # Order is critical.   
+  # Details of the Link index tags like "l=n" do not matter from here on.
+  #
+  H=Hm[1,1]*onehot(T, il0' => 1)*onehot(T, dag(il0) => 1) #Bootstrap with the I op in the top left of Hm
+  H,ih=directsum(H=>il0',Ms[N]=>is[N][1]) #1-D directsum to put M[N] directly below the I op
+  ih=ih,dag(il0) #setup recusion.
+  for i in N-1:-1:1 #2-D directsums to place new blocks below and to the right.
+      H,ih=directsum(H=>ih,Ms[i]=>is[i],tags=["Link,left","Link,right"]) 
+  end
+  IN=Hm[N+1,N+1]*onehot(T, dag(il0) => 1)*onehot(T, ih[1] => dim(ih[1])) #I op in the bottom left of Hm
+  H,_=directsum(H=>ih[2],IN=>il0,tags="Link,right") #1-D directsum to the put I in the bottom row, to the right of M[1]
+  return H
+end
+#
+#  Hm is the InfiniteMPOMatrix
+#  Hs is an array of ITensors, one for the site in the unit cell.
+#  Hi is a CelledVector of ITensors.
+#
+function InfiniteMPO(Hm::InfiniteMPOMatrix)
+  Hs = matrixITensorToITensor.(data(Hm))
+  Hi = CelledVector([H for H in Hs], translator(Hm))
+  lis = CelledVector([inds(H,tags="left")[1] for H in Hs], translator(Hm))
+  ris = CelledVector([inds(H,tags="right")[1] for H in Hs], translator(Hm))
+  site_inds = [commoninds(Hm[j][1, 1], Hm[j][end, end])[1] for j in 1:nsites(Hm)]
+  #
+  #  Create new tags with proper cell and link numbers.  Also daisy chain
+  #  all the indices so right index at j = dag(left index at j+1)
+  #
+  for j in 1:nsites(Hm)
+    newTag = "Link,c=$(getcell(site_inds[j])),l=$(getsite(site_inds[j]))"
+    ir = replacetags(ris[j], tags(ris[j]), newTag) #new right index
+    Hi[j] = replaceinds(Hi[j], [ris[j]], [ir])
+    Hi[j + 1] = replaceinds(Hi[j + 1],[lis[j + 1]],[dag(ir)])
+  end
+  return InfiniteMPO(Hi)
+end

--- a/src/models/models.jl
+++ b/src/models/models.jl
@@ -82,6 +82,14 @@ end
 import ITensors: op
 op(::OpName"Zero", ::SiteType, s::Index) = ITensor(s', dag(s))
 
+function InfiniteMPO(model::Model, s::CelledVector; kwargs...)
+  return InfiniteMPO(model, s, translator(s); kwargs...)
+end
+
+function InfiniteMPO(model::Model, s::CelledVector, translator::Function; kwargs...)
+  InfiniteMPO(InfiniteMPOMatrix(model,s,translator;kwargs...))
+end
+
 function InfiniteMPOMatrix(model::Model, s::CelledVector; kwargs...)
   return InfiniteMPOMatrix(model, s, translator(s); kwargs...)
 end

--- a/src/models/models.jl
+++ b/src/models/models.jl
@@ -87,7 +87,7 @@ function InfiniteMPO(model::Model, s::CelledVector; kwargs...)
 end
 
 function InfiniteMPO(model::Model, s::CelledVector, translator::Function; kwargs...)
-  InfiniteMPO(InfiniteMPOMatrix(model,s,translator;kwargs...))
+  return InfiniteMPO(InfiniteMPOMatrix(model, s, translator; kwargs...))
 end
 
 function InfiniteMPOMatrix(model::Model, s::CelledVector; kwargs...)

--- a/test/test_iMPOConversions.jl
+++ b/test/test_iMPOConversions.jl
@@ -6,141 +6,138 @@ using Test
 #   with l,r terminating vectors, to make a finite lattice MPO.
 #
 function terminate(h::InfiniteMPO)::MPO
-    Ncell=nsites(h)
-    # left termination vector
-    il1=commonind(h[1],h[2])
-    il0,=noncommoninds(h[1],il1,tags="Link")
-    l=ITensor(0.0,il0)
-    l[il0=>dim(il0)]=1.0 #assuming lower reg form in h
-    # right termination vector
-    iln=commonind(h[Ncell-1],h[Ncell])
-    ilnp,=noncommoninds(h[Ncell],iln,tags="Link")
-    r=ITensor(0.0,ilnp)
-    r[ilnp=>1]=1.0 #assuming lower reg form in h
-    # build up a finite MPO
-    hf=MPO(Ncell)
-    hf[1]=dag(l)*h[1] #left terminate
-    hf[Ncell]=h[Ncell]*dag(r) #right terminate
-    for n in 2:Ncell-1
-        hf[n]=h[n] #fill in the bulk.
-    end
-    return hf
+  Ncell = nsites(h)
+  # left termination vector
+  il1 = commonind(h[1], h[2])
+  il0, = noncommoninds(h[1], il1; tags="Link")
+  l = ITensor(0.0, il0)
+  l[il0 => dim(il0)] = 1.0 #assuming lower reg form in h
+  # right termination vector
+  iln = commonind(h[Ncell - 1], h[Ncell])
+  ilnp, = noncommoninds(h[Ncell], iln; tags="Link")
+  r = ITensor(0.0, ilnp)
+  r[ilnp => 1] = 1.0 #assuming lower reg form in h
+  # build up a finite MPO
+  hf = MPO(Ncell)
+  hf[1] = dag(l) * h[1] #left terminate
+  hf[Ncell] = h[Ncell] * dag(r) #right terminate
+  for n in 2:(Ncell - 1)
+    hf[n] = h[n] #fill in the bulk.
+  end
+  return hf
 end
 #
 # Terminate and then call expect
 # for inf ψ and finite h, which is already supported in src/infinitecanonicalmps.jl
 #
 function ITensors.expect(ψ::InfiniteCanonicalMPS, h::InfiniteMPO)
-    return expect(ψ,terminate(h)) #defer to src/infinitecanonicalmps.jl
+  return expect(ψ, terminate(h)) #defer to src/infinitecanonicalmps.jl
 end
 
 #H = ΣⱼΣn (½ S⁺ⱼS⁻ⱼ₊n + ½ S⁻ⱼS⁺ⱼ₊n + SᶻⱼSᶻⱼ₊n)
-function ITensorInfiniteMPS.unit_cell_terms(::Model"heisenbergNNN";NNN::Int64)
-    opsum = OpSum()
-    for n=1:NNN
-        J=1.0/n
-        opsum += J*0.5, "S+", 1, "S-", 1+n
-        opsum += J*0.5, "S-", 1, "S+", 1+n
-        opsum += J,     "Sz", 1, "Sz", 1+n
-    end
-    return opsum
+function ITensorInfiniteMPS.unit_cell_terms(::Model"heisenbergNNN"; NNN::Int64)
+  opsum = OpSum()
+  for n in 1:NNN
+    J = 1.0 / n
+    opsum += J * 0.5, "S+", 1, "S-", 1 + n
+    opsum += J * 0.5, "S-", 1, "S+", 1 + n
+    opsum += J, "Sz", 1, "Sz", 1 + n
+  end
+  return opsum
 end
 
-function ITensorInfiniteMPS.unit_cell_terms(::Model"hubbardNNN";NNN::Int64)
-    U::Float64=0.25
-    t::Float64=1.0
-    V::Float64=0.5
-    opsum = OpSum()
-    opsum += (U, "Nupdn", 1)
-    for n=1:NNN
-        tj,Vj=t/n,V/n
-        opsum += -tj, "Cdagup", 1, "Cup", 1 + n
-        opsum += -tj, "Cdagup", 1 + n, "Cup", 1
-        opsum += -tj, "Cdagdn", 1, "Cdn", 1 + n
-        opsum += -tj, "Cdagdn", 1 + n, "Cdn", 1
-        opsum +=  Vj, "Ntot"  , 1, "Ntot", 1 + n
-    end
-    return opsum
+function ITensorInfiniteMPS.unit_cell_terms(::Model"hubbardNNN"; NNN::Int64)
+  U::Float64 = 0.25
+  t::Float64 = 1.0
+  V::Float64 = 0.5
+  opsum = OpSum()
+  opsum += (U, "Nupdn", 1)
+  for n in 1:NNN
+    tj, Vj = t / n, V / n
+    opsum += -tj, "Cdagup", 1, "Cup", 1 + n
+    opsum += -tj, "Cdagup", 1 + n, "Cup", 1
+    opsum += -tj, "Cdagdn", 1, "Cdn", 1 + n
+    opsum += -tj, "Cdagdn", 1 + n, "Cdn", 1
+    opsum += Vj, "Ntot", 1, "Ntot", 1 + n
+  end
+  return opsum
 end
 
 function ITensors.space(::SiteType"FermionK", pos::Int; p=1, q=1, conserve_momentum=true)
-    if !conserve_momentum
-        return [QN("Nf", -p) => 1, QN("Nf", q - p) => 1]
-    else
-        return [
-        QN(("Nf", -p), ("NfMom", -p * pos)) => 1,
-        QN(("Nf", q - p), ("NfMom", (q - p) * pos)) => 1,
-        ]
-    end
+  if !conserve_momentum
+    return [QN("Nf", -p) => 1, QN("Nf", q - p) => 1]
+  else
+    return [
+      QN(("Nf", -p), ("NfMom", -p * pos)) => 1,
+      QN(("Nf", q - p), ("NfMom", (q - p) * pos)) => 1,
+    ]
+  end
 end
 
 function fermion_momentum_translator(i::Index, n::Integer; N=6)
-    ts = tags(i)
-    translated_ts = ITensorInfiniteMPS.translatecelltags(ts, n)
-    new_i = replacetags(i, ts => translated_ts)
-    for j in 1:length(new_i.space)
-        ch = new_i.space[j][1][1].val
-        mom = new_i.space[j][1][2].val
-        new_i.space[j] = Pair(
-        QN(("Nf", ch), ("NfMom", mom + n * N * ch)), new_i.space[j][2]
-        )
-    end
-    return new_i
-    end
-
-function ITensors.op!(Op::ITensor, opname::OpName, ::SiteType"FermionK", s::Index...)
-    return ITensors.op!(Op, opname, SiteType("Fermion"), s...)
+  ts = tags(i)
+  translated_ts = ITensorInfiniteMPS.translatecelltags(ts, n)
+  new_i = replacetags(i, ts => translated_ts)
+  for j in 1:length(new_i.space)
+    ch = new_i.space[j][1][1].val
+    mom = new_i.space[j][1][2].val
+    new_i.space[j] = Pair(QN(("Nf", ch), ("NfMom", mom + n * N * ch)), new_i.space[j][2])
+  end
+  return new_i
 end
 
-@testset verbose=true "InfiniteMPOMatrix -> InfiniteMPO" begin
-    ferro(n) = "↑"
-    antiferro(n) = isodd(n) ? "↑" : "↓"
+function ITensors.op!(Op::ITensor, opname::OpName, ::SiteType"FermionK", s::Index...)
+  return ITensors.op!(Op, opname, SiteType("Fermion"), s...)
+end
 
-    models=[
-        (Model"heisenbergNNN"(),"S=1/2"),
-        (Model"hubbardNNN"(),"Electron"),
-        
-        ]
-    @testset "H=$model, Ncell=$Ncell, NNN=$NNN, Antiferro=$Af, qns=$qns" for (model,site) in models, qns=[false,true], Ncell in 2:6, NNN in 1:Ncell-1, Af in [true,false]
-#     @testset "H=$model, Ncell=$Ncell, NNN=$NNN, Antiferro=$Af" for (model,site) in models, qns in [true], Ncell in 3:3, NNN in 2:2, Af in [false]
-        
-        if isodd(Ncell) && Af #skip test since Af state does fit inside odd cells.
-            continue
-        end
-        initstate(n) = Af ? antiferro(n) : ferro(n) 
-        model_kwargs=(NNN=NNN,)
-        s = infsiteinds(site, Ncell; initstate,conserve_qns=qns);
-        ψ = InfMPS(s, initstate) 
-        Hi=InfiniteMPO(model, s;model_kwargs...)
-        Hs=InfiniteSum{MPO}(model, s;model_kwargs...)
-        Es=expect(ψ,Hs)
-        Ei=expect(ψ,Hi)
-        #@show Es Ei
-        @test sum(Es[1:Ncell-NNN]) ≈ Ei atol=1e-14
+@testset verbose = true "InfiniteMPOMatrix -> InfiniteMPO" begin
+  ferro(n) = "↑"
+  antiferro(n) = isodd(n) ? "↑" : "↓"
+
+  models = [(Model"heisenbergNNN"(), "S=1/2"), (Model"hubbardNNN"(), "Electron")]
+  @testset "H=$model, Ncell=$Ncell, NNN=$NNN, Antiferro=$Af, qns=$qns" for (model, site) in
+                                                                           models,
+    qns in [false, true],
+    Ncell in 2:6,
+    NNN in 1:(Ncell - 1),
+    Af in [true, false]
+    #     @testset "H=$model, Ncell=$Ncell, NNN=$NNN, Antiferro=$Af" for (model,site) in models, qns in [true], Ncell in 3:3, NNN in 2:2, Af in [false]
+
+    if isodd(Ncell) && Af #skip test since Af state does fit inside odd cells.
+      continue
     end
+    initstate(n) = Af ? antiferro(n) : ferro(n)
+    model_kwargs = (NNN=NNN,)
+    s = infsiteinds(site, Ncell; initstate, conserve_qns=qns)
+    ψ = InfMPS(s, initstate)
+    Hi = InfiniteMPO(model, s; model_kwargs...)
+    Hs = InfiniteSum{MPO}(model, s; model_kwargs...)
+    Es = expect(ψ, Hs)
+    Ei = expect(ψ, Hi)
+    #@show Es Ei
+    @test sum(Es[1:(Ncell - NNN)]) ≈ Ei atol = 1e-14
+  end
 
-    @testset "FQHE Hamitonian" begin
-        N = 6
-        model = Model"fqhe_2b_pot"()
-        model_params = (Vs= [1.0, 0.0, 1.0, 0.0, 0.1], Ly = 3.0, prec = 1e-8)
-        trf=fermion_momentum_translator
-        function initstate(n)
-            mod1(n, 3) == 1 && return 2
-            return 1
-        end
-        p = 1
-        q = 3
-        conserve_momentum = true
-        s = infsiteinds("FermionK", N; translator = trf, initstate, conserve_momentum, p, q);
-        ψ = InfMPS(s, initstate) 
-        Hs=InfiniteSum{MPO}(model, s; model_params...);
-        Hi=InfiniteMPO(model, s,trf;model_params...)
-        #@show inds(Hi[1]) 
-        Es=expect(ψ,Hs)
-        Ei=expect(ψ,Hi)
-        @show Es Ei
-        @test Es[1] ≈ Ei atol=1e-14
+  @testset "FQHE Hamitonian" begin
+    N = 6
+    model = Model"fqhe_2b_pot"()
+    model_params = (Vs=[1.0, 0.0, 1.0, 0.0, 0.1], Ly=3.0, prec=1e-8)
+    trf = fermion_momentum_translator
+    function initstate(n)
+      mod1(n, 3) == 1 && return 2
+      return 1
     end
-
+    p = 1
+    q = 3
+    conserve_momentum = true
+    s = infsiteinds("FermionK", N; translator=trf, initstate, conserve_momentum, p, q)
+    ψ = InfMPS(s, initstate)
+    Hs = InfiniteSum{MPO}(model, s; model_params...)
+    Hi = InfiniteMPO(model, s, trf; model_params...)
+    Es = expect(ψ, Hs)
+    Ei = expect(ψ, Hi)
+    #@show Es Ei
+    @test Es[1] ≈ Ei atol = 1e-14
+  end
 end
 nothing

--- a/test/test_iMPOConversions.jl
+++ b/test/test_iMPOConversions.jl
@@ -1,0 +1,146 @@
+using ITensors
+using ITensorInfiniteMPS
+using Test
+#
+# InfiniteMPO has dangling links at the end of the chain.  We contract these on the outside
+#   with l,r terminating vectors, to make a finite lattice MPO.
+#
+function terminate(h::InfiniteMPO)::MPO
+    Ncell=nsites(h)
+    # left termination vector
+    il1=commonind(h[1],h[2])
+    il0,=noncommoninds(h[1],il1,tags="Link")
+    l=ITensor(0.0,il0)
+    l[il0=>dim(il0)]=1.0 #assuming lower reg form in h
+    # right termination vector
+    iln=commonind(h[Ncell-1],h[Ncell])
+    ilnp,=noncommoninds(h[Ncell],iln,tags="Link")
+    r=ITensor(0.0,ilnp)
+    r[ilnp=>1]=1.0 #assuming lower reg form in h
+    # build up a finite MPO
+    hf=MPO(Ncell)
+    hf[1]=dag(l)*h[1] #left terminate
+    hf[Ncell]=h[Ncell]*dag(r) #right terminate
+    for n in 2:Ncell-1
+        hf[n]=h[n] #fill in the bulk.
+    end
+    return hf
+end
+#
+# Terminate and then call expect
+# for inf ψ and finite h, which is already supported in src/infinitecanonicalmps.jl
+#
+function ITensors.expect(ψ::InfiniteCanonicalMPS, h::InfiniteMPO)
+    return expect(ψ,terminate(h)) #defer to src/infinitecanonicalmps.jl
+end
+
+#H = ΣⱼΣn (½ S⁺ⱼS⁻ⱼ₊n + ½ S⁻ⱼS⁺ⱼ₊n + SᶻⱼSᶻⱼ₊n)
+function ITensorInfiniteMPS.unit_cell_terms(::Model"heisenbergNNN";NNN::Int64)
+    opsum = OpSum()
+    for n=1:NNN
+        J=1.0/n
+        opsum += J*0.5, "S+", 1, "S-", 1+n
+        opsum += J*0.5, "S-", 1, "S+", 1+n
+        opsum += J,     "Sz", 1, "Sz", 1+n
+    end
+    return opsum
+end
+
+function ITensorInfiniteMPS.unit_cell_terms(::Model"hubbardNNN";NNN::Int64)
+    U::Float64=0.25
+    t::Float64=1.0
+    V::Float64=0.5
+    opsum = OpSum()
+    opsum += (U, "Nupdn", 1)
+    for n=1:NNN
+        tj,Vj=t/n,V/n
+        opsum += -tj, "Cdagup", 1, "Cup", 1 + n
+        opsum += -tj, "Cdagup", 1 + n, "Cup", 1
+        opsum += -tj, "Cdagdn", 1, "Cdn", 1 + n
+        opsum += -tj, "Cdagdn", 1 + n, "Cdn", 1
+        opsum +=  Vj, "Ntot"  , 1, "Ntot", 1 + n
+    end
+    return opsum
+end
+
+function ITensors.space(::SiteType"FermionK", pos::Int; p=1, q=1, conserve_momentum=true)
+    if !conserve_momentum
+        return [QN("Nf", -p) => 1, QN("Nf", q - p) => 1]
+    else
+        return [
+        QN(("Nf", -p), ("NfMom", -p * pos)) => 1,
+        QN(("Nf", q - p), ("NfMom", (q - p) * pos)) => 1,
+        ]
+    end
+end
+
+function fermion_momentum_translator(i::Index, n::Integer; N=6)
+    ts = tags(i)
+    translated_ts = ITensorInfiniteMPS.translatecelltags(ts, n)
+    new_i = replacetags(i, ts => translated_ts)
+    for j in 1:length(new_i.space)
+        ch = new_i.space[j][1][1].val
+        mom = new_i.space[j][1][2].val
+        new_i.space[j] = Pair(
+        QN(("Nf", ch), ("NfMom", mom + n * N * ch)), new_i.space[j][2]
+        )
+    end
+    return new_i
+    end
+
+function ITensors.op!(Op::ITensor, opname::OpName, ::SiteType"FermionK", s::Index...)
+    return ITensors.op!(Op, opname, SiteType("Fermion"), s...)
+end
+
+@testset verbose=true "InfiniteMPOMatrix -> InfiniteMPO" begin
+    ferro(n) = "↑"
+    antiferro(n) = isodd(n) ? "↑" : "↓"
+
+    models=[
+        (Model"heisenbergNNN"(),"S=1/2"),
+        (Model"hubbardNNN"(),"Electron"),
+        
+        ]
+    @testset "H=$model, Ncell=$Ncell, NNN=$NNN, Antiferro=$Af, qns=$qns" for (model,site) in models, qns=[false,true], Ncell in 2:6, NNN in 1:Ncell-1, Af in [true,false]
+#     @testset "H=$model, Ncell=$Ncell, NNN=$NNN, Antiferro=$Af" for (model,site) in models, qns in [true], Ncell in 3:3, NNN in 2:2, Af in [false]
+        
+        if isodd(Ncell) && Af #skip test since Af state does fit inside odd cells.
+            continue
+        end
+        initstate(n) = Af ? antiferro(n) : ferro(n) 
+        model_kwargs=(NNN=NNN,)
+        s = infsiteinds(site, Ncell; initstate,conserve_qns=qns);
+        ψ = InfMPS(s, initstate) 
+        Hi=InfiniteMPO(model, s;model_kwargs...)
+        Hs=InfiniteSum{MPO}(model, s;model_kwargs...)
+        Es=expect(ψ,Hs)
+        Ei=expect(ψ,Hi)
+        #@show Es Ei
+        @test sum(Es[1:Ncell-NNN]) ≈ Ei atol=1e-14
+    end
+
+    @testset "FQHE Hamitonian" begin
+        N = 6
+        model = Model"fqhe_2b_pot"()
+        model_params = (Vs= [1.0, 0.0, 1.0, 0.0, 0.1], Ly = 3.0, prec = 1e-8)
+        trf=fermion_momentum_translator
+        function initstate(n)
+            mod1(n, 3) == 1 && return 2
+            return 1
+        end
+        p = 1
+        q = 3
+        conserve_momentum = true
+        s = infsiteinds("FermionK", N; translator = trf, initstate, conserve_momentum, p, q);
+        ψ = InfMPS(s, initstate) 
+        Hs=InfiniteSum{MPO}(model, s; model_params...);
+        Hi=InfiniteMPO(model, s,trf;model_params...)
+        #@show inds(Hi[1]) 
+        Es=expect(ψ,Hs)
+        Ei=expect(ψ,Hi)
+        @show Es Ei
+        @test Es[1] ≈ Ei atol=1e-14
+    end
+
+end
+nothing


### PR DESCRIPTION
Started with Lioc Herviou's code. Uses directsum() to build the InfiniteMPO tensors. Supports dense and block-sparse under the hood (no if hasqns() code blocks).  Tested with Heisenberg/Hubbard models with 1-5 NN interactions and Lioc's FQHE model with Ncell=6 and Ly=3.  
This is not the most efficient way to build InfiniteMPO, the output has extra columns and rows with I's and all zeros that should subsequently  be removed with block repsecting orthogonalization and or compression.  We should be able to build a more efficient  InfiniteMPO by using a block respecting directsum as described in eq. E3 in the Parker paper.  But of users are going to compress anyway, maybe this is not useful.