### PR TITLE
Bump ITensors compat to fix `directsum` issue

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -19,7 +19,7 @@ SplitApplyCombine = "03a91e81-4c3e-53e1-a0a4-9c0c8f19dd66"
 [compat]
 Compat = "3, 4"
 HDF5 = "0.15, 0.16"
-ITensors = "0.3.18"
+ITensors = "0.3.48"
 Infinities = "0.1"
 IterTools = "1"
 KrylovKit = "0.5, 0.6"


### PR DESCRIPTION
This bumps the compat of ITensors to v0.3.48, which includes a fix to `directsum` made in https://github.com/ITensor/ITensors.jl/pull/1221. This fixes an issue that was being discussed in #77 where some functionality that made use of `directum` for converting between MPO formats (`InfiniteBlockMPO` and `InfiniteMPO`) was broken.