### PR TITLE
Add entanglement entropy examples

### DIFF
--- a/examples/vumps/src/entropy.jl
+++ b/examples/vumps/src/entropy.jl
@@ -1,0 +1,32 @@
+using ITensors
+using ITensorInfiniteMPS
+
+# calculate -\sum_i rho_i log(rho_i)
+function calc_vN_entropy(S)
+  SvN, norm = 0.0, 0.0
+  for n in 1:dim(S, 1)
+    p = S[n, n]^2
+    SvN -= p * log(p)
+    norm += p
+  end
+  return SvN, norm
+end
+
+# calculate von Neumann entropy of a MPS cut between sites b-1 and b
+function entropy(ψ::MPS, b)
+  ψ = orthogonalize(ψ, b)
+  U, S, V = svd(ψ[b], (linkind(ψ, b - 1), siteind(ψ, b)))
+  SvN, norm = calc_vN_entropy(S)
+  @assert norm ≈ 1.0
+  return SvN
+end
+
+# calculate von Neumann entropy of an infinite MPS at cut b of the unit cell
+function entropy(ψ::InfiniteCanonicalMPS, b)
+  #calculate entropy
+  C = ψ.C[b]
+  Ũ, S, Ṽ = svd(C, inds(C)[1])
+  SvN, norm = calc_vN_entropy(S)
+  @assert norm ≈ 1.0
+  return SvN
+end

--- a/examples/vumps/src/entropy.jl
+++ b/examples/vumps/src/entropy.jl
@@ -2,7 +2,8 @@ using ITensors
 using ITensorInfiniteMPS
 
 # calculate -\sum_i rho_i log(rho_i)
-function calc_vN_entropy(S)
+function entropy(S::ITensor)
+  @assert order(S) == 2
   SvN, norm = 0.0, 0.0
   for n in 1:dim(S, 1)
     p = S[n, n]^2
@@ -16,7 +17,7 @@ end
 function entropy(ψ::MPS, b)
   ψ = orthogonalize(ψ, b)
   U, S, V = svd(ψ[b], (linkind(ψ, b - 1), siteind(ψ, b)))
-  SvN, norm = calc_vN_entropy(S)
+  SvN, norm = entropy(S)
   @assert norm ≈ 1.0
   return SvN
 end
@@ -26,7 +27,7 @@ function entropy(ψ::InfiniteCanonicalMPS, b)
   #calculate entropy
   C = ψ.C[b]
   Ũ, S, Ṽ = svd(C, inds(C)[1])
-  SvN, norm = calc_vN_entropy(S)
+  SvN, norm = entropy(S)
   @assert norm ≈ 1.0
   return SvN
 end

--- a/examples/vumps/vumps_hubbard_extended.jl
+++ b/examples/vumps/vumps_hubbard_extended.jl
@@ -2,11 +2,9 @@ using ITensors
 using ITensorInfiniteMPS
 
 base_path = joinpath(pkgdir(ITensorInfiniteMPS), "examples", "vumps", "src")
-src_files = [
-  joinpath(base_path, "vumps_subspace_expansion.jl"), joinpath(base_path, "entropy.jl")
-]
+src_files = ["vumps_subspace_expansion.jl", "entropy.jl"]
 for f in src_files
-  include(f)
+  include(joinpath(base_path, f))
 end
 
 ##############################################################################

--- a/examples/vumps/vumps_hubbard_extended.jl
+++ b/examples/vumps/vumps_hubbard_extended.jl
@@ -1,11 +1,9 @@
 using ITensors
 using ITensorInfiniteMPS
 
+base_path = joinpath(pkgdir(ITensorInfiniteMPS), "examples", "vumps", "src")
 src_files = [
-  joinpath(
-    pkgdir(ITensorInfiniteMPS), "examples", "vumps", "src", "vumps_subspace_expansion.jl"
-  ),
-  joinpath(pkgdir(ITensorInfiniteMPS), "examples", "vumps", "src", "entropy.jl"),
+  joinpath(base_path, "vumps_subspace_expansion.jl"), joinpath(base_path, "entropy.jl")
 ]
 for f in src_files
   include(f)

--- a/examples/vumps/vumps_hubbard_extended.jl
+++ b/examples/vumps/vumps_hubbard_extended.jl
@@ -7,30 +7,30 @@ include(
   ),
 )
 
-function entropy_finite(ψ_,b)
+function entropy_finite(ψ_, b)
   ψ = orthogonalize(ψ_, b)
-  U,S,V = svd(ψ[b], (linkind(ψ, b-1), siteind(ψ,b)))
+  U, S, V = svd(ψ[b], (linkind(ψ, b - 1), siteind(ψ, b)))
   SvN = 0.0
-  for n=1:dim(S, 1)
-    p = S[n,n]^2
+  for n in 1:dim(S, 1)
+    p = S[n, n]^2
     SvN -= p * log(p)
   end
   return SvN
 end
 
-function entropy_infinite(ψ_,b)
+function entropy_infinite(ψ_, b)
 
-    #calculate entropy
-    C = ψ_.C[b]
-    Ũ,S,Ṽ = svd(C,inds(C)[1])
-    SvN, tot = 0.0, 0.0
-    for n=1:dim(S, 1)
-      p = S[n,n]^2
-      SvN -= p * log(p)
-      tot += p
-    end
-    @assert tot ≈ 1.
-    return SvN
+  #calculate entropy
+  C = ψ_.C[b]
+  Ũ, S, Ṽ = svd(C, inds(C)[1])
+  SvN, tot = 0.0, 0.0
+  for n in 1:dim(S, 1)
+    p = S[n, n]^2
+    SvN -= p * log(p)
+    tot += p
+  end
+  @assert tot ≈ 1.0
+  return SvN
 end
 ##############################################################################
 # VUMPS parameters
@@ -150,8 +150,8 @@ corr_finite = correlation_matrix(
   ψfinite, "Cdagup", "Cup"; sites=Int(Nfinite / 2):Int(Nfinite / 2 + 9)
 )
 
-S_finite = [entropy_finite(ψfinite,b) for b=Nfinite÷2:Nfinite÷2+N-1]
-S_infinite =[entropy_infinite(ψ,b) for b=1:N]
+S_finite = [entropy_finite(ψfinite, b) for b in (Nfinite ÷ 2):(Nfinite ÷ 2 + N - 1)]
+S_infinite = [entropy_infinite(ψ, b) for b in 1:N]
 
 println("\nResults from VUMPS")
 @show energy_infinite

--- a/examples/vumps/vumps_hubbard_extended.jl
+++ b/examples/vumps/vumps_hubbard_extended.jl
@@ -7,29 +7,30 @@ include(
   ),
 )
 
-function entropy_finite(ψ_, b)
-  ψ = orthogonalize(ψ_, b)
-  U, S, V = svd(ψ[b], (linkind(ψ, b - 1), siteind(ψ, b)))
-  SvN = 0.0
+function calc_vN_entropy(S)
+  SvN, norm = 0.0, 0.0
   for n in 1:dim(S, 1)
     p = S[n, n]^2
     SvN -= p * log(p)
+    norm += p
   end
+  return SvN, norm
+end
+
+function entropy_finite(ψ, b)
+  ψ = orthogonalize(ψ, b)
+  U, S, V = svd(ψ[b], (linkind(ψ, b - 1), siteind(ψ, b)))
+  SvN, norm = calc_vN_entropy(S)
+  @assert norm ≈ 1.0
   return SvN
 end
 
-function entropy_infinite(ψ_, b)
-
+function entropy_infinite(ψ, b)
   #calculate entropy
-  C = ψ_.C[b]
+  C = ψ.C[b]
   Ũ, S, Ṽ = svd(C, inds(C)[1])
-  SvN, tot = 0.0, 0.0
-  for n in 1:dim(S, 1)
-    p = S[n, n]^2
-    SvN -= p * log(p)
-    tot += p
-  end
-  @assert tot ≈ 1.0
+  SvN, norm = calc_vN_entropy(S)
+  @assert norm ≈ 1.0
   return SvN
 end
 ##############################################################################

--- a/examples/vumps/vumps_hubbard_extended.jl
+++ b/examples/vumps/vumps_hubbard_extended.jl
@@ -1,38 +1,16 @@
 using ITensors
 using ITensorInfiniteMPS
 
-include(
+src_files = [
   joinpath(
     pkgdir(ITensorInfiniteMPS), "examples", "vumps", "src", "vumps_subspace_expansion.jl"
   ),
-)
-
-function calc_vN_entropy(S)
-  SvN, norm = 0.0, 0.0
-  for n in 1:dim(S, 1)
-    p = S[n, n]^2
-    SvN -= p * log(p)
-    norm += p
-  end
-  return SvN, norm
+  joinpath(pkgdir(ITensorInfiniteMPS), "examples", "vumps", "src", "entropy.jl"),
+]
+for f in src_files
+  include(f)
 end
 
-function entropy_finite(ψ, b)
-  ψ = orthogonalize(ψ, b)
-  U, S, V = svd(ψ[b], (linkind(ψ, b - 1), siteind(ψ, b)))
-  SvN, norm = calc_vN_entropy(S)
-  @assert norm ≈ 1.0
-  return SvN
-end
-
-function entropy_infinite(ψ, b)
-  #calculate entropy
-  C = ψ.C[b]
-  Ũ, S, Ṽ = svd(C, inds(C)[1])
-  SvN, norm = calc_vN_entropy(S)
-  @assert norm ≈ 1.0
-  return SvN
-end
 ##############################################################################
 # VUMPS parameters
 #
@@ -151,8 +129,8 @@ corr_finite = correlation_matrix(
   ψfinite, "Cdagup", "Cup"; sites=Int(Nfinite / 2):Int(Nfinite / 2 + 9)
 )
 
-S_finite = [entropy_finite(ψfinite, b) for b in (Nfinite ÷ 2):(Nfinite ÷ 2 + N - 1)]
-S_infinite = [entropy_infinite(ψ, b) for b in 1:N]
+S_finite = [entropy(ψfinite, b) for b in (Nfinite ÷ 2):(Nfinite ÷ 2 + N - 1)]
+S_infinite = [entropy(ψ, b) for b in 1:N]
 
 println("\nResults from VUMPS")
 @show energy_infinite

--- a/examples/vumps/vumps_ising.jl
+++ b/examples/vumps/vumps_ising.jl
@@ -2,11 +2,9 @@ using ITensors
 using ITensorInfiniteMPS
 
 base_path = joinpath(pkgdir(ITensorInfiniteMPS), "examples", "vumps", "src")
-src_files = [
-  joinpath(base_path, "vumps_subspace_expansion.jl"), joinpath(base_path, "entropy.jl")
-]
+src_files = ["vumps_subspace_expansion.jl", "entropy.jl"]
 for f in src_files
-  include(f)
+  include(joinpath(base_path, f))
 end
 
 ##############################################################################

--- a/examples/vumps/vumps_ising.jl
+++ b/examples/vumps/vumps_ising.jl
@@ -1,11 +1,9 @@
 using ITensors
 using ITensorInfiniteMPS
 
+base_path = joinpath(pkgdir(ITensorInfiniteMPS), "examples", "vumps", "src")
 src_files = [
-  joinpath(
-    pkgdir(ITensorInfiniteMPS), "examples", "vumps", "src", "vumps_subspace_expansion.jl"
-  ),
-  joinpath(pkgdir(ITensorInfiniteMPS), "examples", "vumps", "src", "entropy.jl"),
+  joinpath(base_path, "vumps_subspace_expansion.jl"), joinpath(base_path, "entropy.jl")
 ]
 for f in src_files
   include(f)

--- a/examples/vumps/vumps_ising.jl
+++ b/examples/vumps/vumps_ising.jl
@@ -7,30 +7,30 @@ include(
   ),
 )
 
-function entropy_finite(ψ_,b)
+function entropy_finite(ψ_, b)
   ψ = orthogonalize(ψ_, b)
-  U,S,V = svd(ψ[b], (linkind(ψ, b-1), siteind(ψ,b)))
+  U, S, V = svd(ψ[b], (linkind(ψ, b - 1), siteind(ψ, b)))
   SvN = 0.0
-  for n=1:dim(S, 1)
-    p = S[n,n]^2
+  for n in 1:dim(S, 1)
+    p = S[n, n]^2
     SvN -= p * log(p)
   end
   return SvN
 end
 
-function entropy_infinite(ψ_,b)
+function entropy_infinite(ψ_, b)
 
-    #calculate entropy
-    C = ψ_.C[b]
-    Ũ,S,Ṽ = svd(C,inds(C)[1])
-    SvN, tot = 0.0, 0.0
-    for n=1:dim(S, 1)
-      p = S[n,n]^2
-      SvN -= p * log(p)
-      tot += p
-    end
-    @assert tot ≈ 1.
-    return SvN
+  #calculate entropy
+  C = ψ_.C[b]
+  Ũ, S, Ṽ = svd(C, inds(C)[1])
+  SvN, tot = 0.0, 0.0
+  for n in 1:dim(S, 1)
+    p = S[n, n]^2
+    SvN -= p * log(p)
+    tot += p
+  end
+  @assert tot ≈ 1.0
+  return SvN
 end
 
 ##############################################################################
@@ -129,8 +129,10 @@ Sz2_infinite = expect(ψ.AL[2] * ψ.C[2], "Sz")
 @show Sz1_finite, Sz2_finite
 @show Sz1_infinite, Sz2_infinite
 
-S_finite = [entropy_finite(ψ_finite,b) for b=nsite_finite÷2:nsite_finite÷2+nsite-1]
-S_infinite =[entropy_infinite(ψ,b) for b=1:nsite]
+S_finite = [
+  entropy_finite(ψ_finite, b) for b in (nsite_finite ÷ 2):(nsite_finite ÷ 2 + nsite - 1)
+]
+S_infinite = [entropy_infinite(ψ, b) for b in 1:nsite]
 @show S_finite
 @show S_infinite
 

--- a/examples/vumps/vumps_ising.jl
+++ b/examples/vumps/vumps_ising.jl
@@ -1,37 +1,14 @@
 using ITensors
 using ITensorInfiniteMPS
 
-include(
+src_files = [
   joinpath(
     pkgdir(ITensorInfiniteMPS), "examples", "vumps", "src", "vumps_subspace_expansion.jl"
   ),
-)
-
-function calc_vN_entropy(S)
-  SvN, norm = 0.0, 0.0
-  for n in 1:dim(S, 1)
-    p = S[n, n]^2
-    SvN -= p * log(p)
-    norm += p
-  end
-  return SvN, norm
-end
-
-function entropy_finite(ψ, b)
-  ψ = orthogonalize(ψ, b)
-  U, S, V = svd(ψ[b], (linkind(ψ, b - 1), siteind(ψ, b)))
-  SvN, norm = calc_vN_entropy(S)
-  @assert norm ≈ 1.0
-  return SvN
-end
-
-function entropy_infinite(ψ, b)
-  #calculate entropy
-  C = ψ.C[b]
-  Ũ, S, Ṽ = svd(C, inds(C)[1])
-  SvN, norm = calc_vN_entropy(S)
-  @assert norm ≈ 1.0
-  return SvN
+  joinpath(pkgdir(ITensorInfiniteMPS), "examples", "vumps", "src", "entropy.jl"),
+]
+for f in src_files
+  include(f)
 end
 
 ##############################################################################
@@ -130,10 +107,8 @@ Sz2_infinite = expect(ψ.AL[2] * ψ.C[2], "Sz")
 @show Sz1_finite, Sz2_finite
 @show Sz1_infinite, Sz2_infinite
 
-S_finite = [
-  entropy_finite(ψ_finite, b) for b in (nsite_finite ÷ 2):(nsite_finite ÷ 2 + nsite - 1)
-]
-S_infinite = [entropy_infinite(ψ, b) for b in 1:nsite]
+S_finite = [entropy(ψ_finite, b) for b in (nsite_finite ÷ 2):(nsite_finite ÷ 2 + nsite - 1)]
+S_infinite = [entropy(ψ, b) for b in 1:nsite]
 @show S_finite
 @show S_infinite
 

--- a/examples/vumps/vumps_ising.jl
+++ b/examples/vumps/vumps_ising.jl
@@ -7,6 +7,32 @@ include(
   ),
 )
 
+function entropy_finite(ψ_,b)
+  ψ = orthogonalize(ψ_, b)
+  U,S,V = svd(ψ[b], (linkind(ψ, b-1), siteind(ψ,b)))
+  SvN = 0.0
+  for n=1:dim(S, 1)
+    p = S[n,n]^2
+    SvN -= p * log(p)
+  end
+  return SvN
+end
+
+function entropy_infinite(ψ_,b)
+
+    #calculate entropy
+    C = ψ_.C[b]
+    Ũ,S,Ṽ = svd(C,inds(C)[1])
+    SvN, tot = 0.0, 0.0
+    for n=1:dim(S, 1)
+      p = S[n,n]^2
+      SvN -= p * log(p)
+      tot += p
+    end
+    @assert tot ≈ 1.
+    return SvN
+end
+
 ##############################################################################
 # VUMPS/TDVP parameters
 #
@@ -102,3 +128,10 @@ Sz2_infinite = expect(ψ.AL[2] * ψ.C[2], "Sz")
 
 @show Sz1_finite, Sz2_finite
 @show Sz1_infinite, Sz2_infinite
+
+S_finite = [entropy_finite(ψ_finite,b) for b=nsite_finite÷2:nsite_finite÷2+nsite-1]
+S_infinite =[entropy_infinite(ψ,b) for b=1:nsite]
+@show S_finite
+@show S_infinite
+
+nothing

--- a/examples/vumps/vumps_ising.jl
+++ b/examples/vumps/vumps_ising.jl
@@ -7,29 +7,30 @@ include(
   ),
 )
 
-function entropy_finite(ψ_, b)
-  ψ = orthogonalize(ψ_, b)
-  U, S, V = svd(ψ[b], (linkind(ψ, b - 1), siteind(ψ, b)))
-  SvN = 0.0
+function calc_vN_entropy(S)
+  SvN, norm = 0.0, 0.0
   for n in 1:dim(S, 1)
     p = S[n, n]^2
     SvN -= p * log(p)
+    norm += p
   end
+  return SvN, norm
+end
+
+function entropy_finite(ψ, b)
+  ψ = orthogonalize(ψ, b)
+  U, S, V = svd(ψ[b], (linkind(ψ, b - 1), siteind(ψ, b)))
+  SvN, norm = calc_vN_entropy(S)
+  @assert norm ≈ 1.0
   return SvN
 end
 
-function entropy_infinite(ψ_, b)
-
+function entropy_infinite(ψ, b)
   #calculate entropy
-  C = ψ_.C[b]
+  C = ψ.C[b]
   Ũ, S, Ṽ = svd(C, inds(C)[1])
-  SvN, tot = 0.0, 0.0
-  for n in 1:dim(S, 1)
-    p = S[n, n]^2
-    SvN -= p * log(p)
-    tot += p
-  end
-  @assert tot ≈ 1.0
+  SvN, norm = calc_vN_entropy(S)
+  @assert norm ≈ 1.0
   return SvN
 end
 

--- a/test/test_vumps.jl
+++ b/test/test_vumps.jl
@@ -36,7 +36,7 @@ end
   ψfinite = randomMPS(sfinite, initstate)
   nsweeps = 20
   energy_finite_total, ψfinite = dmrg(
-    Hfinite, ψfinite; nsweeps, maxdims=10, cutoff=1e-10, outputlevel=0
+    Hfinite, ψfinite; nsweeps, maxdim=10, cutoff=1e-10, outputlevel=0
   )
 
   @testset "VUMPS/TDVP with: multisite_update_alg = $multisite_update_alg, conserve_qns = $conserve_qns, nsites = $nsites, time_step = $time_step, localham_type = $localham_type" for multisite_update_alg in
@@ -142,7 +142,7 @@ end
   ψfinite = randomMPS(sfinite, initstate)
   nsweeps = 20
   energy_finite_total, ψfinite = dmrg(
-    Hfinite, ψfinite; nsweeps, maxdims=10, cutoff=1e-10, outputlevel=0
+    Hfinite, ψfinite; nsweeps, maxdim=10, cutoff=1e-10, outputlevel=0
   )
 
   multisite_update_alg = "sequential"

--- a/test/test_vumpsmpo.jl
+++ b/test/test_vumpsmpo.jl
@@ -105,7 +105,7 @@ end
   ψfinite = randomMPS(sfinite, initstate)
   nsweeps = 20
   energy_finite_total, ψfinite = dmrg(
-    Hfinite, ψfinite; nsweeps, maxdims=10, cutoff=1e-10, outputlevel=0
+    Hfinite, ψfinite; nsweeps, maxdim=10, cutoff=1e-10, outputlevel=0
   )
   Szs_finite = expect(ψfinite, "Sz")
 


### PR DESCRIPTION
Added two functions to compare von Neumann entanglement entropy for the finite and infinite DMRG examples. 
See formula 21 at [arxiv:1810.07006](https://arxiv.org/pdf/1810.07006.pdf)

Also modified some tests to work for the latest ITensors dmrg api