### PR TITLE
Fix 2d heisenberg example and add warning

### DIFF
--- a/examples/vumps/vumps_2d_heisenberg.jl
+++ b/examples/vumps/vumps_2d_heisenberg.jl
@@ -34,9 +34,9 @@ function ITensorInfiniteMPS.unit_cell_terms(::Model"heisenberg2D"; width)
   opsum = OpSum()
   for i in 1:width
     # Vertical
-    opsum += -0.5, "S+", i, "S-", mod(i, width) + 1
-    opsum += -0.5, "S-", i, "S+", mod(i, width) + 1
-    opsum += "Sz", i, "Sz", mod(i, width) + 1
+    opsum += -0.5, "S+", i, "S-", i + 1
+    opsum += -0.5, "S-", i, "S+", i + 1
+    opsum += "Sz", i, "Sz", i + 1
     # Horizontal
     opsum += -0.5, "S+", i, "S-", i + width
     opsum += -0.5, "S-", i, "S+", i + width

--- a/examples/vumps/vumps_2d_heisenberg.jl
+++ b/examples/vumps/vumps_2d_heisenberg.jl
@@ -35,17 +35,17 @@ function ITensorInfiniteMPS.unit_cell_terms(::Model"heisenberg2D"; width, yperio
   opsum = OpSum()
   for i in 1:width
     # Vertical
-    opsum += -0.5, "S+", i, "S-", i + 1
-    opsum += -0.5, "S-", i, "S+", i + 1
+    opsum -= 0.5, "S+", i, "S-", i + 1
+    opsum -= 0.5, "S-", i, "S+", i + 1
     opsum += "Sz", i, "Sz", i + 1
     # Horizontal
-    opsum += -0.5, "S+", i, "S-", i + width
-    opsum += -0.5, "S-", i, "S+", i + width
+    opsum -= 0.5, "S+", i, "S-", i + width
+    opsum -= 0.5, "S-", i, "S+", i + width
     opsum += "Sz", i, "Sz", i + width
   end
   if yperiodic
-    opsum += -0.5, "S+", 1, "S-", width
-    opsum += -0.5, "S-", 1, "S+", width
+    opsum -= 0.5, "S+", 1, "S-", width
+    opsum -= 0.5, "S-", 1, "S+", width
     opsum += "Sz", 1, "Sz", width
   end
   return opsum

--- a/examples/vumps/vumps_2d_heisenberg.jl
+++ b/examples/vumps/vumps_2d_heisenberg.jl
@@ -34,9 +34,9 @@ function ITensorInfiniteMPS.unit_cell_terms(::Model"heisenberg2D"; width)
   opsum = OpSum()
   for i in 1:width
     # Vertical
-    opsum += -0.5, "S+", i, "S-", mod(i + 1, width)
-    opsum += -0.5, "S-", i, "S+", mod(i + 1, width)
-    opsum += "Sz", i, "Sz", mod(i + 1, width)
+    opsum += -0.5, "S+", i, "S-", mod(i, width) + 1
+    opsum += -0.5, "S-", i, "S+", mod(i, width) + 1
+    opsum += "Sz", i, "Sz", mod(i, width) + 1
     # Horizontal
     opsum += -0.5, "S+", i, "S-", i + width
     opsum += -0.5, "S-", i, "S+", i + width

--- a/examples/vumps/vumps_2d_heisenberg.jl
+++ b/examples/vumps/vumps_2d_heisenberg.jl
@@ -19,6 +19,7 @@ conserve_qns = true
 solver_tol = (x -> x / 10)
 outer_iters = 10 # Number of times to increase the bond dimension
 width = 4
+yperiodic = false # OBC vs cylinder
 
 ##############################################################################
 # CODE BELOW HERE DOES NOT NEED TO BE MODIFIED
@@ -30,7 +31,7 @@ initstate(n) = isodd(n) ? "↑" : "↓"
 s = infsiteinds("S=1/2", N; conserve_qns, initstate)
 ψ = InfMPS(s, initstate)
 
-function ITensorInfiniteMPS.unit_cell_terms(::Model"heisenberg2D"; width)
+function ITensorInfiniteMPS.unit_cell_terms(::Model"heisenberg2D"; width, yperiodic)
   opsum = OpSum()
   for i in 1:width
     # Vertical
@@ -42,12 +43,17 @@ function ITensorInfiniteMPS.unit_cell_terms(::Model"heisenberg2D"; width)
     opsum += -0.5, "S-", i, "S+", i + width
     opsum += "Sz", i, "Sz", i + width
   end
+  if yperiodic
+    opsum += -0.5, "S+", 1, "S-", width
+    opsum += -0.5, "S-", 1, "S+", width
+    opsum += "Sz", 1, "Sz", width
+  end
   return opsum
 end
 model = Model("heisenberg2D")
 
 # Form the Hamiltonian
-H = InfiniteSum{MPO}(model, s; width)
+H = InfiniteSum{MPO}(model, s; width, yperiodic)
 
 # Check translational invariance
 # println("\nCheck translation invariance of the initial VUMPS state")

--- a/src/models/models.jl
+++ b/src/models/models.jl
@@ -248,7 +248,9 @@ function infinite_terms(opsum::OpSum; kwargs...)
   # check that we don't have terms we will ignore
   dropped = filter(x -> x <= 0, keys(opsum_cell_dict))
   if length(dropped) > 0
-    @warn "The input unit cell terms include terms that are being ignored on sites: $([d for d in dropped])"
+    error(
+      "The input unit cell terms include terms that are being ignored on sites: $([d for d in dropped])",
+    )
   end
 
   # Assumes each site in the unit cell has a term

--- a/src/models/models.jl
+++ b/src/models/models.jl
@@ -245,6 +245,12 @@ function infinite_terms(opsum::OpSum; kwargs...)
   # stores all terms starting on site `i`.
   opsum_cell_dict = groupreduce(minimum ∘ ITensors.sites, +, opsum)
   nsites = maximum(keys(opsum_cell_dict))
+  # check that we don't have terms we will ignore
+  dropped = filter(x -> x <= 0, keys(opsum_cell_dict))
+  if length(dropped) > 0
+    @warn "The input unit cell terms include terms that are being ignored on sites: $([d for d in dropped])"
+  end
+
   # Assumes each site in the unit cell has a term
   for j in 1:nsites
     if !haskey(opsum_cell_dict, j)


### PR DESCRIPTION
As reported in https://itensor.discourse.group/t/vumps-example-2d-heisenberg-model-interaction-term/2052?u=ryanlevy

The 2D heisenberg example misses some operators, which is fixed in this version. I've also included a warning to help users catch this in the future, happy to take suggestions on alternative "fixes"