### PR TITLE
Update for 1.11 and workflows

### DIFF
--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -4,6 +4,22 @@ on:
     types:
       - created
   workflow_dispatch:
+    inputs:
+      lookback:
+        default: "3"
+permissions:
+  actions: read
+  checks: read
+  contents: write
+  deployments: read
+  issues: read
+  discussions: read
+  packages: read
+  pages: read
+  pull-requests: read
+  repository-projects: read
+  security-events: read
+  statuses: read
 jobs:
   TagBot:
     if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'

--- a/.github/workflows/format_check.yml
+++ b/.github/workflows/format_check.yml
@@ -1,7 +1,7 @@
 name: Format check
 on:
   push:
-    branches: [master]
+    branches: [main]
     tags: [v*]
   pull_request:
 
@@ -10,8 +10,8 @@ jobs:
     name: "Format Check"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@v1
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v2
         with:
           version: 1
       - name: Install JuliaFormatter and format

--- a/.github/workflows/format_pr.yml
+++ b/.github/workflows/format_pr.yml
@@ -6,7 +6,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Install JuliaFormatter and format
         run: |
           julia  -e 'import Pkg; Pkg.add("JuliaFormatter")'
@@ -15,7 +15,7 @@ jobs:
       # https://github.com/peter-evans/create-pull-request#reference-example
       - name: Create Pull Request
         id: cpr
-        uses: peter-evans/create-pull-request@v3
+        uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: Format .jl files

--- a/.github/workflows/format_suggestions.yml
+++ b/.github/workflows/format_suggestions.yml
@@ -13,7 +13,7 @@ jobs:
   format:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@latest
         with:
           version: 1

--- a/src/ITensors.jl
+++ b/src/ITensors.jl
@@ -125,7 +125,7 @@ end
 #
 
 ITensors.IndexSet(is::IndexSet...) = unioninds(is)
-ITensors.IndexSet(is::Tuple{Vararg{<:IndexSet}}) = unioninds(is...)
+ITensors.IndexSet(is::Tuple{Vararg{IndexSet}}) = unioninds(is...)
 
 Base.copy(is::IndexSet) = IndexSet(copy.(ITensors.data(is)))
 

--- a/src/infinitecanonicalmps.jl
+++ b/src/infinitecanonicalmps.jl
@@ -51,7 +51,7 @@ end
 # of Index (Tuple, Vector, ITensor, etc.)
 indtype(i::Index) = typeof(i)
 indtype(T::Type{<:Index}) = T
-indtype(is::Tuple{Vararg{<:Index}}) = eltype(is)
+indtype(is::Tuple{Vararg{Index}}) = eltype(is)
 indtype(is::Vector{<:Index}) = eltype(is)
 indtype(A::ITensor...) = indtype(inds.(A))
 


### PR DESCRIPTION
This removes the `Vararg` warning found in Julia 1.11 as well as updates the github workflows to the latest versions (used in ITensors.jl)