### PR TITLE
Gauge improvements

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ITensorInfiniteMPS"
 uuid = "1dc1fb26-a137-4954-ae60-1bd4106e95ad"
 authors = ["Matthew Fishman <mfishman@flatironinstitute.org> and contributors"]
-version = "0.2.0"
+version = "0.2.1"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/examples/vumps/vumps_hubbard_extended.jl
+++ b/examples/vumps/vumps_hubbard_extended.jl
@@ -56,6 +56,7 @@ subspace_expansion_kwargs = (cutoff=cutoff, maxdim=maxdim)
 
 println("\nRun VUMPS on initial product state, unit cell size $N")
 ψ = vumps_subspace_expansion(H, ψ; outer_iters, subspace_expansion_kwargs, vumps_kwargs)
+ψ = orthogonalize(ψ.AL, :; tol=1e-14) # ensure translation invariance
 
 # Check translational invariance
 println("\nCheck translational invariance of optimized infinite MPS")

--- a/src/infinitecanonicalmps.jl
+++ b/src/infinitecanonicalmps.jl
@@ -252,7 +252,7 @@ end
 function finite_mps(
   ψ::InfiniteCanonicalMPS,
   range::AbstractRange;
-  ortho_lims::UnitRange=last(range):last(range),
+  ortho_lims::AbstractUnitRange=last(range):last(range),
 )
   @assert isone(step(range))
   @assert first(ortho_lims) == last(ortho_lims) # TODO: variable ortho_lims

--- a/src/orthogonalize.jl
+++ b/src/orthogonalize.jl
@@ -45,7 +45,7 @@ function right_orthogonalize(
     #@show λ₁ᴿᴺ
     #@show v₁ᴿᴺ
     @show norm(v₁ᴿᴺ - swapinds(dag(v₁ᴿᴺ), reverse(Pair(inds(v₁ᴿᴺ)...))))
-    @warn("v₁ᴿᴺ is not hermitian within rtol=$ishermitian_rtol")
+    @warn("v₁ᴿᴺ is not hermitian, passed kwargs: $ishermitian_kwargs")
   end
   if norm(imag(v₁ᴿᴺ)) / norm(v₁ᴿᴺ) > 1e-13
     println(

--- a/src/orthogonalize.jl
+++ b/src/orthogonalize.jl
@@ -2,7 +2,12 @@ using KrylovKit: schursolve, Arnoldi
 # TODO: call as `orthogonalize(ψ, -∞)`
 # TODO: could use commontags(ψ) as a default for left_tags
 function right_orthogonalize(
-  ψ::InfiniteMPS; left_tags=ts"Left", right_tags=ts"Right", tol::Real=1e-12, eager=false
+  ψ::InfiniteMPS;
+  left_tags=ts"Left",
+  right_tags=ts"Right",
+  tol::Real=1e-12,
+  eager=true,
+  htol::Real=1e-10,
 )
   # A transfer matrix made from the 1st unit cell of the infinite MPS
   T = TransferMatrix(ψ)
@@ -36,7 +41,7 @@ function right_orthogonalize(
 
   # Fix the phase of the diagonal to make Hermitian
   v₁ᴿᴺ .*= conj(sign(v₁ᴿᴺ[1, 1]))
-  if !ishermitian(v₁ᴿᴺ; rtol=tol)
+  if !ishermitian(v₁ᴿᴺ; rtol=htol)
     @show λ₁ᴿᴺ
     @show v₁ᴿᴺ
     @show norm(v₁ᴿᴺ - swapinds(dag(v₁ᴿᴺ), reverse(Pair(inds(v₁ᴿᴺ)...))))

--- a/src/orthogonalize.jl
+++ b/src/orthogonalize.jl
@@ -1,3 +1,4 @@
+using KrylovKit: schursolve, Arnoldi
 # TODO: call as `orthogonalize(ψ, -∞)`
 # TODO: could use commontags(ψ) as a default for left_tags
 function right_orthogonalize(
@@ -12,9 +13,15 @@ function right_orthogonalize(
   # Start by getting the right eivenvector/eigenvalue of T
   # TODO: make a function `right_environments(::InfiniteMPS)` that computes
   # all of the right environments using `eigsolve` and shifting unit cells
-  λ⃗₁ᴿᴺ, v⃗₁ᴿᴺ, eigsolve_info = eigsolve(T, v₁ᴿᴺ, 1, :LM; tol=tol)
+
+  # original eigsolve function, switch to schur which enforces real
+  #λ⃗₁ᴿᴺ, v⃗₁ᴿᴺ, eigsolve_info = eigsolve(T, v₁ᴿᴺ, 1, :LM; tol, eager=true)
+  TT, v⃗₁ᴿᴺ, λ⃗₁ᴿᴺ, eigsolve_info = schursolve(T, v₁ᴿᴺ, 1, :LM, Arnoldi(; tol))
   λ₁ᴿᴺ, v₁ᴿᴺ = λ⃗₁ᴿᴺ[1], v⃗₁ᴿᴺ[1]
 
+  if size(TT, 2) > 1 && TT[2, 1] != 0
+    @warn("Largest transfer matrix eigenvector is not real?")
+  end
   if imag(λ₁ᴿᴺ) / norm(λ₁ᴿᴺ) > 1e-15
     @show λ₁ᴿᴺ
     error(

--- a/src/orthogonalize.jl
+++ b/src/orthogonalize.jl
@@ -2,7 +2,7 @@ using KrylovKit: schursolve, Arnoldi
 # TODO: call as `orthogonalize(ψ, -∞)`
 # TODO: could use commontags(ψ) as a default for left_tags
 function right_orthogonalize(
-  ψ::InfiniteMPS; left_tags=ts"Left", right_tags=ts"Right", tol::Real=1e-12, eager=true
+  ψ::InfiniteMPS; left_tags=ts"Left", right_tags=ts"Right", tol::Real=1e-12, eager=false
 )
   # A transfer matrix made from the 1st unit cell of the infinite MPS
   T = TransferMatrix(ψ)

--- a/src/orthogonalize.jl
+++ b/src/orthogonalize.jl
@@ -42,8 +42,6 @@ function right_orthogonalize(
   # Fix the phase of the diagonal to make Hermitian
   v₁ᴿᴺ .*= conj(sign(v₁ᴿᴺ[1, 1]))
   if !ishermitian(v₁ᴿᴺ; ishermitian_kwargs...)
-    #@show λ₁ᴿᴺ
-    #@show v₁ᴿᴺ
     @show norm(v₁ᴿᴺ - swapinds(dag(v₁ᴿᴺ), reverse(Pair(inds(v₁ᴿᴺ)...))))
     @warn("v₁ᴿᴺ is not hermitian, passed kwargs: $ishermitian_kwargs")
   end

--- a/src/orthogonalize.jl
+++ b/src/orthogonalize.jl
@@ -7,7 +7,7 @@ function right_orthogonalize(
   right_tags=ts"Right",
   tol::Real=1e-12,
   eager=true,
-  ishermitian_rtol::Real=tol * 100,
+  ishermitian_kwargs=(; rtol=tol * 100),
 )
   # A transfer matrix made from the 1st unit cell of the infinite MPS
   T = TransferMatrix(ψ)
@@ -41,7 +41,7 @@ function right_orthogonalize(
 
   # Fix the phase of the diagonal to make Hermitian
   v₁ᴿᴺ .*= conj(sign(v₁ᴿᴺ[1, 1]))
-  if !ishermitian(v₁ᴿᴺ; rtol=ishermitian_rtol)
+  if !ishermitian(v₁ᴿᴺ; ishermitian_kwargs...)
     #@show λ₁ᴿᴺ
     #@show v₁ᴿᴺ
     @show norm(v₁ᴿᴺ - swapinds(dag(v₁ᴿᴺ), reverse(Pair(inds(v₁ᴿᴺ)...))))

--- a/src/orthogonalize.jl
+++ b/src/orthogonalize.jl
@@ -125,11 +125,6 @@ function mixed_canonical(
   if λ ≉ one(λ)
     error("λ should be approximately 1 after orthogonalization, instead it is $λ")
   end
-  # tags have been added, remove them now
-  # This is broken until we fix the tags for C
-  #removetags!(ψᴸ, left_tags)
-  #removetags!(ψᴿ, right_tags)
-  #removetags!(C,addtags(right_tags,left_tags))
   return InfiniteCanonicalMPS(ψᴸ, C, ψᴿ)
 end
 


### PR DESCRIPTION
This implements two improvements:

- `finite_mps` can now have its gauge center be on the first site instead of the last site
- `orthogonalize` ensures a real Hermitian transfer matrix eigenvector thanks to `schursolve` (shout out @lkdvos for the tip)

The first change is a small speed improvement for long `finite_mps` calls as `correlation_matrix` will immediately move the orthogonality center to the first site

```
julia> @btime corrR = correlation_matrix(finite_mps(ψ,1:24; ortho="right"),"Cdagup","Cup"; sites=2:24+1);
  57.864 ms (900184 allocations: 146.93 MiB)

julia> @btime corrL = correlation_matrix(finite_mps(ψ,1:24; ortho="left"),"Cdagup","Cup"; sites=2:24+1);
  47.981 ms (764616 allocations: 117.28 MiB)
```

The second change includes the additional "gauge fixing" of the output of vumps in the Hubbard example, which should probably always be done so that the state you want to measure has a more consistent `C` matrix. 